### PR TITLE
Add support for eth-sign

### DIFF
--- a/Bitski/Classes/Core/Bitski+Web3.swift
+++ b/Bitski/Classes/Core/Bitski+Web3.swift
@@ -1,0 +1,70 @@
+//
+//  Bitski+Web3.swift
+//  AppAuth
+//
+//  Created by Josh Pyles on 6/5/19.
+//
+
+import Foundation
+import Web3
+import PromiseKit
+
+public extension Web3.Eth {
+
+    func sign(from: EthereumAddress, message: EthereumData, response: @escaping Web3.Web3ResponseCompletion<EthereumData>) {
+        let req = RPCRequest<EthereumValue>(
+            id: properties.rpcId,
+            jsonrpc: Web3.jsonrpc,
+            method: "eth_sign",
+            params: [from, message]
+        )
+        properties.provider.send(request: req, response: response)
+    }
+    
+    func sign(from: EthereumAddress, message: EthereumData) -> Promise<EthereumData> {
+        return Promise { resolver in
+            sign(from: from, message: message) { result in
+                switch result.status {
+                case let .success(value):
+                    resolver.fulfill(value)
+                case let .failure(error):
+                    resolver.reject(error)
+                }
+            }
+        }
+    }
+    
+    func sendRawTransaction(_ rawTransaction: EthereumData, response: @escaping Web3.Web3ResponseCompletion<EthereumData>){
+        let req = RPCRequest<EthereumValue>(
+            id: properties.rpcId,
+            jsonrpc: Web3.jsonrpc,
+            method: "eth_sendRawTransaction",
+            params: [rawTransaction]
+        )
+        properties.provider.send(request: req, response: response)
+    }
+    
+    func sendRawTransaction(_ rawTransaction: EthereumData) -> Promise<EthereumData> {
+        return Promise { resolver in
+            sendRawTransaction(rawTransaction) { result in
+                switch result.status {
+                case let .success(value):
+                    resolver.fulfill(value)
+                case let .failure(error):
+                    resolver.reject(error)
+                }
+            }
+        }
+    }
+    
+}
+
+public extension RPCResponse {
+    
+    init(id: Int = 0, jsonrpc: String = "2.0", result: Result?, error: Error? = nil) {
+        self.id = id
+        self.jsonrpc = jsonrpc
+        self.result = result
+        self.error = error
+    }
+}

--- a/Bitski/Classes/Core/BitskiTransaction.swift
+++ b/Bitski/Classes/Core/BitskiTransaction.swift
@@ -80,20 +80,12 @@ struct MessageSignatureObject: Codable {
         self.from = address
         self.message = message
     }
+}
+
+extension BitskiTransaction {
     
-    /// Creates an instance from an array of boxed ethereum values
-    
-    /// - Parameters:
-    ///   - params: An array of EthereumValues in the format:
-    ///     - index 0: EthereumAddress
-    ///     - index 1: EthereumData
-    init?(params: [EthereumValue]) {
-        guard let firstValue = params.first, let values = firstValue.array, values.count >= 2 else { return nil }
-        if let address = try? EthereumAddress(ethereumValue: values[0]), let data = values[1].ethereumData {
-            self.from = address
-            self.message = data
-        } else {
-            return nil
-        }
+    init(payload: Payload, kind: BitskiTransaction.Kind, chainId: Int) {
+        self.init(id: UUID(), payload: payload, kind: kind, context: Context(chainId: chainId))
     }
+    
 }

--- a/Bitski/Classes/Core/TransactionSigner.swift
+++ b/Bitski/Classes/Core/TransactionSigner.swift
@@ -1,0 +1,161 @@
+//
+//  TransactionSigner.swift
+//  Bitski
+//
+//  Created by Josh Pyles on 6/7/19.
+//
+
+import Foundation
+import PromiseKit
+import Web3
+
+/// A class that is responsible for mediating signature requests from your app to the user.
+/// You should not need to create an instance yourself, but rather use its methods via the Bitski instance.
+public class TransactionSigner: NetworkClient {
+    
+    enum SignerError: Swift.Error {
+        /// No authdelegate was provided, thus we cannot get an access token
+        case noDelegate
+        /// The request failed
+        case requestFailed(Swift.Error?)
+        /// The request or response is missing data
+        case missingData
+    }
+    
+    /// Base URL for Bitski's custom APIs, such as the transaction API
+    let apiBaseURL: URL
+    
+    /// Base URL for Bitski's web interface. Used for requests that require authorization.
+    let webBaseURL: URL
+    
+    /// URL for redirecting back into the app
+    let redirectURL: URL
+    
+    /// The current BitskiAuthorizationAgent for requests requiring authorization (must be retained).
+    private var currentAuthAgent: BitskiAuthorizationAgent?
+    
+    /// Delegate to provide up to date access tokens for each request
+    weak var authDelegate: BitskiAuthDelegate?
+    
+    /// Creates a new instance of TransactionSigner
+    ///
+    /// - Parameters:
+    ///   - apiBaseURL: The base URL for the Bitski transaction API
+    ///   - webBaseURL: The base URL for the Bitski signer website
+    ///   - redirectURL: This app's registered redirect url
+    ///   - session: (optional) A custom URLSession to use for requests
+    required public init(apiBaseURL: URL, webBaseURL: URL, redirectURL: URL, session: URLSession = URLSession(configuration: .default)) {
+        self.apiBaseURL = apiBaseURL
+        self.webBaseURL = webBaseURL
+        self.redirectURL = redirectURL
+        super.init(session: session)
+    }
+    
+    /// Signs a message from the given account.
+    ///
+    /// - Parameters:
+    ///   - from: The account to sign from. This must be an account that the current user owns.
+    ///   - message: The message to sign.
+    /// - Returns:
+    ///     Promise<Result>. Generic for compatibility with Web3.swift. You should specialize the promise in
+    ///     your implementation as Promise<EthereumData>.
+    public func sign<Result: Codable>(from: EthereumAddress, message: EthereumData) -> Promise<Result> {
+        let payload = MessageSignatureObject(from: from, message: message)
+        let transaction = BitskiTransaction(payload: payload, kind: .sign, chainId: 0)
+        return firstly {
+            self.getAccessToken()
+        }.then { accessToken in
+            self.submitTransaction(transaction: transaction, accessToken: accessToken)
+        }.then { accessToken in
+            self.requestAuthorization(transaction: transaction)
+        }
+    }
+    
+    /// Signs a transaction from the given account
+    ///
+    /// - Parameters:
+    ///   - transaction: The transaction to sign
+    ///   - network: (optional) a Bitski.Network object to sign from. The chain id will be used to prevent replay attacks.
+    /// - Returns:
+    ///     A Promise<Result> object. Generic for compatibility with Web3.swift. You should specialize the promise in
+    ///     your implementation as Promise<EthereumData>.
+    public func sign<Result: Codable>(transaction: EthereumTransaction, network: Bitski.Network = .mainnet) -> Promise<Result> {
+        let transaction = BitskiTransaction(payload: transaction, kind: .signTransaction, chainId: network.chainId)
+        return firstly {
+            self.getAccessToken()
+        }.then { accessToken in
+            self.submitTransaction(transaction: transaction, accessToken: accessToken)
+        }.then { transaction in
+            self.requestAuthorization(transaction: transaction)
+        }
+    }
+    
+    /// Creates a BitskiAuthorizationAgent
+    /// Note: This is used in the tests to create a mock agent
+    func createAuthorizationAgent() -> BitskiAuthorizationAgent {
+        return BitskiAuthorizationAgent(baseURL: self.webBaseURL, redirectURL: self.redirectURL)
+    }
+    
+    /// Retrieve an access token from the server
+    private func getAccessToken() -> Promise<String> {
+        return Promise { resolver in
+            guard let authDelegate = authDelegate else {
+                throw SignerError.noDelegate
+            }
+            authDelegate.getCurrentAccessToken(completion: resolver.resolve)
+        }
+    }
+    
+    /// Requests authorization from the user for a given transaction
+    /// Will open a url on bitski.com to allow the user to review and approve / reject the transaction.
+    ///
+    /// - Parameters:
+    ///   - transaction: BitskiTransaction to request authorization for
+    /// - Returns: A Promise resolving with the result of the signature request
+    private func requestAuthorization<Payload, Result: Codable>(transaction: BitskiTransaction<Payload>) -> Promise<Result> {
+        return firstly { () -> Promise<Data> in
+            // Retain an instance of our authorization agent
+            self.currentAuthAgent = self.createAuthorizationAgent()
+            
+            // Request authorization from user
+            return self.currentAuthAgent!.requestAuthorization(transactionId: transaction.id.uuidString)
+        }.recover { error throws -> Promise<Data> in
+            // Release the instance of authorization agent
+            self.currentAuthAgent = nil
+            throw error
+        }.map { data throws -> RPCResponse<Result> in
+            // Release the instance of authorization agent
+            self.currentAuthAgent = nil
+            return try self.decoder.decode(RPCResponse<Result>.self, from: data)
+        }.map { response throws -> Result in
+            if let result = response.result {
+                return result
+            }
+            
+            if let error = response.error {
+                throw error
+            }
+            
+            throw SignerError.requestFailed(nil)
+        }
+    }
+    
+    /// Persists the transaction to Bitski via http request
+    ///
+    /// - Parameters:
+    ///   - transaction: BitskiTransaction to persist
+    ///   - accessToken: The current access token for the user
+    /// - Returns: A Promise resolving with the persisted transaction.
+    private func submitTransaction<Payload>(transaction: BitskiTransaction<Payload>, accessToken: String) -> Promise<BitskiTransaction<Payload>> {
+        return firstly {
+            return self.encode(body: transaction, withPrefix: "transaction")
+        }.then { (data: Data) -> Promise<Data> in
+            let url = URL(string: "transactions", relativeTo: self.apiBaseURL)!
+            return self.sendRequest(url: url, accessToken: accessToken, method: "POST", body: data)
+        }.map { data throws -> BitskiTransaction<Payload> in
+            let parsed = try self.decoder.decode(BitskiTransactionResponse<Payload>.self, from: data)
+            return parsed.transaction
+        }
+    }
+    
+}

--- a/Example/Bitski.xcodeproj/project.pbxproj
+++ b/Example/Bitski.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* MiscTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* MiscTests.swift */; };
 		AB038E26F332FDEFD229CD17 /* Pods_Bitski_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73A95D11A38B3B6CB8D843BA /* Pods_Bitski_Example.framework */; };
-		E820CBFA20EE92AD005CCE05 /* MockAuthAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820CBF920EE92AD005CCE05 /* MockAuthAgent.swift */; };
+		E820CBFA20EE92AD005CCE05 /* MockAuthenticationAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820CBF920EE92AD005CCE05 /* MockAuthenticationAgent.swift */; };
 		E820CBFC20EE9395005CCE05 /* MockBitski.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820CBFB20EE9395005CCE05 /* MockBitski.swift */; };
 		E820CC0120EEAAEE005CCE05 /* MockBitskiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820CC0020EEAAEE005CCE05 /* MockBitskiProvider.swift */; };
 		E820CC0420EEB801005CCE05 /* token.json in Resources */ = {isa = PBXBuildFile; fileRef = E820CC0220EEB801005CCE05 /* token.json */; };
@@ -33,6 +33,10 @@
 		E893FEF320F012600065F964 /* empty.json in Resources */ = {isa = PBXBuildFile; fileRef = E893FEF220F012600065F964 /* empty.json */; };
 		E89F7CD2225BF1770017E822 /* create-transaction.json in Resources */ = {isa = PBXBuildFile; fileRef = E89F7CD1225BF1770017E822 /* create-transaction.json */; };
 		E89F7CD4225BF3E80017E822 /* block-number.json in Resources */ = {isa = PBXBuildFile; fileRef = E89F7CD3225BF3E80017E822 /* block-number.json */; };
+		E8D6781522AF1E15003E4AB1 /* TransactionSignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D6781422AF1E15003E4AB1 /* TransactionSignerTests.swift */; };
+		E8D6781822B018D4003E4AB1 /* MockAuthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D6781622B017AA003E4AB1 /* MockAuthDelegate.swift */; };
+		E8D6781A22B01F61003E4AB1 /* MockTransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D6781922B01F61003E4AB1 /* MockTransactionSigner.swift */; };
+		E8D6781C22B02C30003E4AB1 /* create-sign-transaction.json in Resources */ = {isa = PBXBuildFile; fileRef = E8D6781B22B02C30003E4AB1 /* create-sign-transaction.json */; };
 		E8D8CABF225D40D300AB575C /* BitskiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D8CABE225D40D300AB575C /* BitskiTests.swift */; };
 		E8D8CAC1225D40EA00AB575C /* BitskiProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D8CAC0225D40EA00AB575C /* BitskiProviderTests.swift */; };
 		E8D8CAC3225D40FD00AB575C /* BitskiTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D8CAC2225D40FD00AB575C /* BitskiTransactionTests.swift */; };
@@ -73,7 +77,7 @@
 		B743ED0B6EE095E7DBB68242 /* Pods-Bitski_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bitski_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Bitski_Example/Pods-Bitski_Example.release.xcconfig"; sourceTree = "<group>"; };
 		C3109604084DD994DE4C7CB4 /* Pods-Bitski_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bitski_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Bitski_Tests/Pods-Bitski_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		DBC92345A3AE96CFBA8AE979 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		E820CBF920EE92AD005CCE05 /* MockAuthAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthAgent.swift; sourceTree = "<group>"; };
+		E820CBF920EE92AD005CCE05 /* MockAuthenticationAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationAgent.swift; sourceTree = "<group>"; };
 		E820CBFB20EE9395005CCE05 /* MockBitski.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBitski.swift; sourceTree = "<group>"; };
 		E820CC0020EEAAEE005CCE05 /* MockBitskiProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBitskiProvider.swift; sourceTree = "<group>"; };
 		E820CC0220EEB801005CCE05 /* token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = token.json; sourceTree = "<group>"; };
@@ -91,6 +95,10 @@
 		E893FEF220F012600065F964 /* empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = empty.json; sourceTree = "<group>"; };
 		E89F7CD1225BF1770017E822 /* create-transaction.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "create-transaction.json"; sourceTree = "<group>"; };
 		E89F7CD3225BF3E80017E822 /* block-number.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "block-number.json"; sourceTree = "<group>"; };
+		E8D6781422AF1E15003E4AB1 /* TransactionSignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSignerTests.swift; sourceTree = "<group>"; };
+		E8D6781622B017AA003E4AB1 /* MockAuthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthDelegate.swift; sourceTree = "<group>"; };
+		E8D6781922B01F61003E4AB1 /* MockTransactionSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransactionSigner.swift; sourceTree = "<group>"; };
+		E8D6781B22B02C30003E4AB1 /* create-sign-transaction.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "create-sign-transaction.json"; sourceTree = "<group>"; };
 		E8D8CABE225D40D300AB575C /* BitskiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitskiTests.swift; sourceTree = "<group>"; };
 		E8D8CAC0225D40EA00AB575C /* BitskiProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitskiProviderTests.swift; sourceTree = "<group>"; };
 		E8D8CAC2225D40FD00AB575C /* BitskiTransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitskiTransactionTests.swift; sourceTree = "<group>"; };
@@ -188,6 +196,7 @@
 				E8D8CAC2225D40FD00AB575C /* BitskiTransactionTests.swift */,
 				E8D8CAC6225D5FCD00AB575C /* BitskiAuthorizationAgentTests.swift */,
 				E8D8CAD6225EC62500AB575C /* NetworkClientTests.swift */,
+				E8D6781422AF1E15003E4AB1 /* TransactionSignerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -196,8 +205,10 @@
 			isa = PBXGroup;
 			children = (
 				607FACEA1AFB9204008FA782 /* Info.plist */,
-				E820CBF920EE92AD005CCE05 /* MockAuthAgent.swift */,
+				E820CBF920EE92AD005CCE05 /* MockAuthenticationAgent.swift */,
+				E8D6781622B017AA003E4AB1 /* MockAuthDelegate.swift */,
 				E8D8CAC8225EA98C00AB575C /* MockAuthorizationAgent.swift */,
+				E8D6781922B01F61003E4AB1 /* MockTransactionSigner.swift */,
 				E820CBFB20EE9395005CCE05 /* MockBitski.swift */,
 				E893FEEE20F009EB0065F964 /* OHHTTPStubs+Bitski.swift */,
 				E820CC0020EEAAEE005CCE05 /* MockBitskiProvider.swift */,
@@ -241,6 +252,7 @@
 				E820CC0220EEB801005CCE05 /* token.json */,
 				E89F7CD1225BF1770017E822 /* create-transaction.json */,
 				E89F7CD3225BF3E80017E822 /* block-number.json */,
+				E8D6781B22B02C30003E4AB1 /* create-sign-transaction.json */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";
@@ -353,6 +365,7 @@
 				E89F7CD4225BF3E80017E822 /* block-number.json in Resources */,
 				E820CC0520EEB801005CCE05 /* send-transaction.json in Resources */,
 				E893FEEC20EFEA9F0065F964 /* get-block-1.json in Resources */,
+				E8D6781C22B02C30003E4AB1 /* create-sign-transaction.json in Resources */,
 				E893FEEB20EFEA9F0065F964 /* get-block-2.json in Resources */,
 				E820CC0420EEB801005CCE05 /* token.json in Resources */,
 				E820CC0920EEBE2E005CCE05 /* eth-accounts.json in Resources */,
@@ -490,12 +503,15 @@
 				E8D8CAD7225EC62500AB575C /* NetworkClientTests.swift in Sources */,
 				E8D8CAC1225D40EA00AB575C /* BitskiProviderTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* MiscTests.swift in Sources */,
-				E820CBFA20EE92AD005CCE05 /* MockAuthAgent.swift in Sources */,
+				E820CBFA20EE92AD005CCE05 /* MockAuthenticationAgent.swift in Sources */,
 				E8D8CAC9225EA98C00AB575C /* MockAuthorizationAgent.swift in Sources */,
+				E8D6781522AF1E15003E4AB1 /* TransactionSignerTests.swift in Sources */,
 				E820CC0120EEAAEE005CCE05 /* MockBitskiProvider.swift in Sources */,
+				E8D6781822B018D4003E4AB1 /* MockAuthDelegate.swift in Sources */,
 				E8D8CABF225D40D300AB575C /* BitskiTests.swift in Sources */,
 				E893FEEF20F009EB0065F964 /* OHHTTPStubs+Bitski.swift in Sources */,
 				E8D8CAC3225D40FD00AB575C /* BitskiTransactionTests.swift in Sources */,
+				E8D6781A22B01F61003E4AB1 /* MockTransactionSigner.swift in Sources */,
 				E820CBFC20EE9395005CCE05 /* MockBitski.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Bitski/Base.lproj/Main.storyboard
+++ b/Example/Bitski/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -122,20 +123,32 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pbi-aq-CuC">
-                                <rect key="frame" x="127" y="376" width="120" height="30"/>
-                                <state key="normal" title="Send Transaction"/>
-                                <connections>
-                                    <action selector="sendTransaction" destination="iMY-1i-Z5W" eventType="touchUpInside" id="H8s-lF-Yed"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="8ez-BV-H78">
+                                <rect key="frame" x="127.5" y="376" width="120" height="68"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N7K-dO-FY8">
+                                        <rect key="frame" x="0.0" y="0.0" width="120" height="30"/>
+                                        <state key="normal" title="Sign Data"/>
+                                        <connections>
+                                            <action selector="signData" destination="iMY-1i-Z5W" eventType="touchUpInside" id="nty-ko-NLR"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pbi-aq-CuC">
+                                        <rect key="frame" x="0.0" y="38" width="120" height="30"/>
+                                        <state key="normal" title="Send Transaction"/>
+                                        <connections>
+                                            <action selector="sendTransaction" destination="iMY-1i-Z5W" eventType="touchUpInside" id="H8s-lF-Yed"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="wby-A0-n50" firstAttribute="centerY" secondItem="ExZ-22-1W0" secondAttribute="centerY" id="27Q-ZG-MOJ"/>
-                            <constraint firstItem="pbi-aq-CuC" firstAttribute="centerX" secondItem="ExZ-22-1W0" secondAttribute="centerX" id="BfL-iP-zKI"/>
-                            <constraint firstItem="pbi-aq-CuC" firstAttribute="top" secondItem="2fc-Ne-jL1" secondAttribute="bottom" constant="20" id="Xbo-NP-0fs"/>
                             <constraint firstItem="wby-A0-n50" firstAttribute="centerX" secondItem="ExZ-22-1W0" secondAttribute="centerX" id="bGx-xX-qdD"/>
+                            <constraint firstItem="8ez-BV-H78" firstAttribute="centerX" secondItem="ExZ-22-1W0" secondAttribute="centerX" id="mn2-O0-DcB"/>
+                            <constraint firstItem="8ez-BV-H78" firstAttribute="top" secondItem="wby-A0-n50" secondAttribute="bottom" constant="20" id="voC-mM-UnS"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,404 +7,413 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		01B5DBC0B30624E0DCAFA069A36DE928 /* SolidityType+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE60B0DC2F679ECBEEB3C41F648D70 /* SolidityType+Codable.swift */; };
-		01E960D0F4D41AEEE206E0E9BA3D3F9B /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = A677727BC17C6EE4E46BF3A3C9F32077 /* field_5x52.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		00E14AA6FD4A16365F80ABBDE54132DC /* Exports+Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608427808F04683EE5DBF3804B97333D /* Exports+Web3.swift */; };
 		022742787C4A305C3AB968E23ECF7E9C /* OHHTTPStubsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DF2971B3B9A50014F7F2897CC463876 /* OHHTTPStubsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0298C3F0E570CB928C2CB7EB1EAD37E1 /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = 288BECCA915ADBE5BF22DB25E1F60D69 /* ecmult_const.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		02B003D980C9000421EEB996E7FC2318 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA6C0362282DCBD4867F0BB6470DA92 /* Padding.swift */; };
-		03A7079F9232960BCC86088B3CA4340C /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207EFF6805B6AA69AF0F173DEEFCE081 /* hang.swift */; };
+		043570A44388483604ED2D812787E1A6 /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9366D0BC78D757C256ABDFFF93FF8 /* ZeroPadding.swift */; };
 		044D03CBBC2AED2994AB0199C9FCF092 /* OIDServiceConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 24416977C48E4B00F915DE215FC5B3A6 /* OIDServiceConfiguration.m */; };
-		046C83D63EA0997BE9021DEB77252D89 /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B026CB700EFBBA6396E196430A0F53 /* AES.swift */; };
+		04AC9C6802BD16696F84B80864CFF8C8 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D247FDBD818DAE92F9A4FA69B04ACED5 /* PromiseKit.framework */; };
 		051FD68F1510179C79C542C7F1051E76 /* OHHTTPStubsResponse+JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = B44D988379477544E4AB3DC3D783B490 /* OHHTTPStubsResponse+JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		06260E614058886CB730147062CCAFF4 /* Multiplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94573028FBCA93D0DC3F776A6D5EB3A2 /* Multiplication.swift */; };
-		0776BCE0B3FD420EC3BA5035E6CD5B9C /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C583BFDFCF9B743BFE3268CE492FDB6 /* Cryptors.swift */; };
-		078512706CB24BCE77B882F01323ED5B /* Values+GeneralHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FABE3563F13AF3E852B143E5CB5B2B /* Values+GeneralHashable.swift */; };
+		06F95B44E6223CB143438F3E7A020FB4 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F995DDFC83C919B3418829E1E109F1AA /* Utils+Foundation.swift */; };
+		0737AC64345A5EF2C190368F300011D9 /* EthereumTransactionObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55549D1729BB0CB8854AF2678A87E526 /* EthereumTransactionObject.swift */; };
 		084932690E9736AE4DBC640C175A23C9 /* DataConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68912D74DC8F73C2F3DD5B6DBACA3EF6 /* DataConversion.swift */; };
+		08F7442858546590E96369BAE2277203 /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 98AB9E3F6B154E054173EF618F29F9F5 /* basic-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0919A426FFC6E05DFE23A5655D0E2985 /* ABI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9453B5EA76BC1DE094895414344D650D /* ABI.swift */; };
+		09C20BA41EA491E9AA14698E81F6F188 /* BitskiAuthorizationAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423569E307C93EECDB2618D13D01783F /* BitskiAuthorizationAgent.swift */; };
 		0A1D2630EF1381E5C8A96461CC740ADC /* OIDResponseTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E79110E768C3AEC6F96B9D9A39E5AF03 /* OIDResponseTypes.m */; };
 		0AD0420D799875AC2C6214C839D87859 /* OIDClientMetadataParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F7C1A3550F1A67144AF6FF1E988431 /* OIDClientMetadataParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0AD12990D029D92F559E4D434A2E8A66 /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = 73F27A18BC7FA00779D71DEBF1CE9212 /* field.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0B48C89706B9EE9EBD2C930CD11AD4E6 /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341545CED74E916909AAE4161553ED92 /* UInt128.swift */; };
+		0AF954110B17542A0659E7243D7B932B /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AFD8A594AA00F81AF7E07854B30EB0 /* eckey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0B66E867684025387326123B1724E7F9 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359098AD4B7E7B8388E033B6CB600264 /* Operators.swift */; };
 		0CEAEDD406B59E764DFE44486E9478F1 /* Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569C6618253F4B0D39D25C7AB6753F9 /* Hashable.swift */; };
 		0DD1761DAE818C3AE4A0F3FF21390B2A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		0E3E7F862A6BB18BA2A4CB063665B704 /* Eth+Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B747871EAD46685D43E5B4F6CF2029 /* Eth+Contract.swift */; };
-		0F26766300CD4AA83FDF17312A1B276E /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B0FCAE10440C4D78EFF352455FFFED /* Resolver.swift */; };
+		0DD3824744038E06EEE0876B3768166D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
+		0F221C81ABAA8F837FD7317341FB5E21 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7CA88F632C9D92DF72C2A971F67FBD /* CustomStringConvertible.swift */; };
+		0F46D435F3A65ED96D733EA5B0482BB5 /* Types+RLPItemConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D3FAD2A1C774E4D88E6140EBA8A714 /* Types+RLPItemConvertible.swift */; };
 		0F5584E3C5570871FC2B7A35C63728BB /* OIDIDToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 57FE626C181A2D77767106785E8FDA20 /* OIDIDToken.m */; };
-		0F924E519F1C99F14B81F59B0A0E3753 /* BitskiAuthorizationAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8617647093472681BA67A01A4C34AE8 /* BitskiAuthorizationAgent.swift */; };
-		0FAFE0E74FF2F4AB8C67EF03CA9E5CB4 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D247FDBD818DAE92F9A4FA69B04ACED5 /* PromiseKit.framework */; };
-		0FD208782A5E5B8B63190830B3118FFE /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85213F3EB385B5D2F930BDB126504B56 /* Error.swift */; };
-		104952E9036CB05B81A00F60B2D90B7A /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9366D0BC78D757C256ABDFFF93FF8 /* ZeroPadding.swift */; };
-		131C244A136E6968A871930E290C6871 /* Web3-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10B5F40771370A90A662268D21518DED /* Web3-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1360A6E72D6A4D77287EF7491AFA528E /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D98C57FEAFA6B582B3176D8225EFD60 /* ecmult_gen.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1513A15EBCC10294414DB1301B90DE52 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB170ADAE77E9219B2050F28131F194E /* BlockModeOptions.swift */; };
+		113E0733E8E9ED3663F0B64AE74203FC /* Values+GeneralHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FABE3563F13AF3E852B143E5CB5B2B /* Values+GeneralHashable.swift */; };
+		1273E10159BE193F30DFA65C06746514 /* Bytes+HexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35032FCB9E2DE326EFFDEF538AC5794 /* Bytes+HexString.swift */; };
+		13DD69E53349B0A5B988D7A099E3EF59 /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7DE5847361FFD6D6AD0FADDC6F65 /* AES.Cryptors.swift */; };
+		146D071C100040BD8766D12D5CF0DDC2 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 55371D0B7FCAB1177169AE5AE1CB9E2B /* dispatch_promise.m */; };
 		15B8525E75477E609DB0009B5E58F16C /* NSURLRequest+HTTPBodyTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C46F3E9DB7995EE4EB6BDF5215717 /* NSURLRequest+HTTPBodyTesting.m */; };
-		165DE6A967B46023A72687F2204FBF4A /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1B5AEC0AA36645E9A06973F0223BFE /* ECB.swift */; };
 		16E8516FF990B1E2891E3E77F36C97A6 /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = CF9354C573A7C5D09A148F8FE4ABC211 /* OHHTTPStubsResponse+JSON.m */; };
+		1732AAADBC86C8187D0C439DA70D7FDD /* Types+EthereumValueConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B748F74D7CB3BB28E46690DBCEB7933 /* Types+EthereumValueConvertible.swift */; };
 		1815EBA98781539045CA15241814E833 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		18F1AF655FFD3CB85FB5CAA20CC8CF8F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		1915190FC7F42F85F11C5692AA16AA0C /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FAE3DEC5A9E4A976CD76C7BD651AE9 /* AnyPromise.swift */; };
-		19AFFF46CEEB326B7FCE7200B4D1E39B /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 72793E0694B634AD8C12A8867C75A2AD /* race.m */; };
+		186D64249E2C8E00D7FF8C38592EC0CD /* Bitski+Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9077BD92E076FE2A0FA268E7F6D169BA /* Bitski+Web3.swift */; };
 		19EF203D29B00B67CBFAB87E2A3D0319 /* OIDFieldMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = E21CD1BCE7AD90FAC8BB2CA768CAD819 /* OIDFieldMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1CE3306796F283C52C262794768C2518 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		1DBE5A7AFB064FB9EC6F6B1086F8B5B4 /* RLPEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982632EC9D55A6B9EB539218DA465EBF /* RLPEncoder.swift */; };
-		1F12A0380D9CD4E984BFC3A0527C85D3 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 063393ACE9B5BF415EE22C147653A250 /* after.m */; };
+		1BE73ED62DD6C0F5B8CF2201C9EC7EB2 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB5D9C589FEB3A6153A08E709B67CA /* PCBC.swift */; };
+		1E26C406545971DF4710FAEA7D5E25F8 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2352C2FB3CD478181F88B13B8C93F41B /* CompactMap.swift */; };
+		1E4ADAF0EBCFDF7D2B530BB6865898F4 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = F84090BFF59F356C2BF0CFB5CBA4B393 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E8B73FBB8E980838711257F8FDDBAE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
+		1E90D5FB06D38A6FDC8846B71EB9FC5E /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B029357F44677068E3781CBAA68538E /* num_gmp.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1FAB570247F2134315D927E0CA1F2C50 /* EthereumTransactionReceiptObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95675BF32A6FB18A4F9EE6D812F7A560 /* EthereumTransactionReceiptObject.swift */; };
 		1FCAA5C0D89076E8CBA8013B435FDB00 /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2523008AF6A9A8346E0334C84E7CB005 /* Addition.swift */; };
 		2039BDB696B5C65F57C3AA48FA555EB1 /* WordsAndBits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AA2D41114AFE7E32E632D7A99080F0 /* WordsAndBits.swift */; };
-		204732775A196B8BA7DC3DE0BF8B9304 /* Secp256k1+CTXCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3323506B9F80BEF58C12E509F721FB /* Secp256k1+CTXCreator.swift */; };
-		208066A2AF3A56E2C1A15FF849D7CE89 /* Bytes+TrimLeadingZeros.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218C6513B3261248A499DE5FD6F74BB2 /* Bytes+TrimLeadingZeros.swift */; };
-		210DC77E376BCBDE5FD04FBB6331DAAF /* EthereumBlockObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78A4EE227F0D49BB12D36FA5E5BCD02 /* EthereumBlockObject.swift */; };
-		21847663595D2C361282CA267269DF70 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AC37F8E0319DE43D28F75C2CC91156 /* after.swift */; };
-		21D821CF36134B7D275CA5BF1D446FB8 /* EthereumValueConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225277D0DEC1B786BFB9C68A6BD06143 /* EthereumValueConvertible.swift */; };
+		20CBE2BAFADB6A184A1741C08102E653 /* SolidityFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37D8EC2C776EFD071F386425CFF195 /* SolidityFunction.swift */; };
 		225A3562560CE3C2498E86F5EB327072 /* Compatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F6440CCAC2E249321FB1DA7E6EA6E30 /* Compatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2414EDF736667AD7F69E1C46FF1A8859 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFDEDB8C756357CDD0779A61721838 /* Catchable.swift */; };
-		24EF78E14FEE520E8C98BA79EF30F4FE /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2352C2FB3CD478181F88B13B8C93F41B /* CompactMap.swift */; };
-		24FFB8C0EED5619CD526E258ACEADC80 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4953586D8E95AE42DE002C5E6CBF90B /* BigInt.framework */; };
+		2341612F58D32CD9D8442267AF010100 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CA1CBD19A09BD05AE31E9051D2EB9 /* BatchedCollection.swift */; };
+		2376A3A5E848EB59D69644F69C29EF44 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8015B6CBD7311CADC0A6C13003DEF4 /* Deprecations.swift */; };
+		23D0609CBB9380032F01B8AB682624A8 /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF15AFFD5CCE3F2F61C17732675AAE96 /* SHA2.swift */; };
 		2562F282760B810115E0E00E2FA9519F /* OIDServiceDiscovery.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AEEC2FB9E7407BD4B868C369A1C92C /* OIDServiceDiscovery.m */; };
-		2574A6D9A6A3FA0FF43BFE0D46B41882 /* ABIDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D85D86975A923B27BAF210B195A12E /* ABIDecoder.swift */; };
-		25DADCC6EDA44DA0AC810114E9222D50 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C8C35B8882B88756D97295473516F8 /* BlockEncryptor.swift */; };
 		2600087445795A08C1DC7E443ABBDE9B /* OIDExternalUserAgentIOS.m in Sources */ = {isa = PBXBuildFile; fileRef = E93769DC97ADA1987D1EF61E6DF9B38F /* OIDExternalUserAgentIOS.m */; };
-		275172F4EAF1C2ED55E2F8B08DF2E80E /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B02F52F78E30C83E5D9E06C594E9E21 /* ecmult.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2802D2BF38E2D70FCD7B4461138A3634 /* ABIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF1AC965E53A1A13762320B26C7435 /* ABIEncoder.swift */; };
-		28C0C389131FF359F1C6AF2D09568A38 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0E0E87CAD90DABCB6C48C362EA0EFB /* UInt32+Extension.swift */; };
+		26083FCE643B3A0967B2901D9C82737D /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75A651660B17D786A5C0233DDFEEE0D /* UInt64+Extension.swift */; };
+		280FCB894D39CBAD16C922D807E20B7A /* String+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8FE4BB3617E0975EAFB4FF5A38474F /* String+Conversion.swift */; };
+		282E9D62EC6261F48995C103A304A54E /* EthereumCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55186C72814D9D47C340E95D2F6FF55 /* EthereumCall.swift */; };
 		28F87456F395D194B02E812E6B1DCDAC /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E191E0EAA186463271B4A1617D14DBFA /* Addition.swift */; };
 		29628D5637676F6AD2BF0A7E2A3182CB /* OHHTTPStubsMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 33170F7AFC5A8669262E70B9B724531A /* OHHTTPStubsMethodSwizzling.m */; };
-		29A8C44EE0BECC808852FEC73C200D9B /* secp256k1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A90896AC737FBBF78E7AF0E33EE26E54 /* secp256k1.framework */; };
-		2ACE83411C9CBBC7E1283D0284BE4747 /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D19CBB2AD10A2BE64017C029DB5544F /* main_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2BAE3FD7BE6169946CDECAA734B15A31 /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 79CCF8F943E860BD647634D6E6592D55 /* hash.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		299096096EB57C3935009E01D41501C5 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AC37F8E0319DE43D28F75C2CC91156 /* after.swift */; };
+		2B410376EC00F5678A6D9775E2D4533D /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85128C5230DFA05AAFF5803A752C5CD /* SHA3.swift */; };
+		2B443D0FABEB50A77698A5948EE9A3B8 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = E014DC54C758893D25AB553171CE5571 /* CFB.swift */; };
 		2BC3E811C4F9BFE8763BBC366C81481E /* OIDErrorUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FF32AA51507F385ECFF916D076888141 /* OIDErrorUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2CCB41558F76FAAC66C05C094545D8D5 /* OIDTokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B65212FD4D9C49BCDEFE04AD1299AB /* OIDTokenResponse.m */; };
+		2CE246371017E85E736D4A2745540548 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0281C90391425FA81092F4AB5D587232 /* Digest.swift */; };
 		2CE49E8D0FF17DC7A758352BB672C385 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		2CE65C18CB037C33FA374F27F7D33D84 /* lax_der_privatekey_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2D731059EF1F76890764E18F4F5445 /* lax_der_privatekey_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2DA7754537417935D2CDB4951C667087 /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 336C4CEBA01501692EBF7B59CEBA2EE1 /* field_5x52_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2D0DEE07002C3F64FCE134AB04D250CB /* Web3+HTTPInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7464D2036BC40A05A648D966E88AD2E /* Web3+HTTPInitializer.swift */; };
+		2E67C60EC00B886E8949F103DF9FFD4E /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5316F6915675EB5CE9BE363FFF9C17BD /* Data+Extension.swift */; };
 		2EC9864D819359752C0D618960BA5C0F /* OIDURLSessionProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BF089B95F5F2CF9A8AAF77B604427114 /* OIDURLSessionProvider.m */; };
 		2FB881B557336AF57C4C6AAADC28806E /* OIDAuthState.h in Headers */ = {isa = PBXBuildFile; fileRef = D9CB78190832C777F8DA7C937D01D2C5 /* OIDAuthState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		308B6B640E9877439FF7ECFFAD0FFD8C /* Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C773F84EEA68D065561E327512D5E07 /* Hashable.swift */; };
 		30A3282BC68364F2271E5787B0590DA1 /* OIDExternalUserAgentIOSCustomBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = B5B602734BE1444BB29CDCE9575612C2 /* OIDExternalUserAgentIOSCustomBrowser.m */; };
+		30B4E8877010BF287F08AD4972D20710 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966AD8278867B5D7B53FC09EB8534190 /* race.swift */; };
 		3110B06329321BC1CED745047AA8DE61 /* OIDAuthorizationService.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C13CE6B614EADAC62DFFF17103C1279 /* OIDAuthorizationService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		316623AAA5EB720E713682DC2A004543 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE81304779F5EA312711B9C62235C48B /* CryptoSwift.framework */; };
 		316974605E17E62AEED8C0E47B6597D9 /* OHHTTPStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = AC651B5FCB131AD40E7F7DAB5DD427E2 /* OHHTTPStubs.m */; };
-		329A3608AB84F04D743DD123EA9B7E64 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4953586D8E95AE42DE002C5E6CBF90B /* BigInt.framework */; };
-		336D6FA88A72AE9A289052D76E8D0DE4 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356D9DD4EF074E7BE0DCDF66030B439 /* String+FoundationExtension.swift */; };
-		33DEBDD4E3F2A201B7408221213EEE5D /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E5B7E2B4FA94715584D1735FD4238 /* hang.m */; };
-		34156A2B69FAD65CA6CF88CC0D714999 /* secp256k1_ec_mult_static_context.h in Headers */ = {isa = PBXBuildFile; fileRef = 56097B565B5719EBD17A627426094B58 /* secp256k1_ec_mult_static_context.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3486B6A76E757787188C43A217243C42 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1DF17A7DC85ADD2AB77212DD076A52 /* Utils.swift */; };
-		34D2C11B0E874E9E215F35DA178D9049 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBBF4F4A7B4EE050AA9ED13E11B1C5E /* join.m */; };
-		3794437FBC4B9E3EDBCB3A46BF5A6CE5 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F55D4FFC2E7B05F9DEBEA3243A6A99 /* String+Extension.swift */; };
-		382EB6ED08E7ED308B2CD16CD73F732E /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6D766B5B9AC66E08AAC62F16621BCF /* scalar_8x32_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3225582BA1C09E52CB4394DD17951CCF /* secp256k1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A90896AC737FBBF78E7AF0E33EE26E54 /* secp256k1.framework */; };
+		33044B8732A00986251AA8B211544334 /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A74A4AC42DDE4E06563017906E62CBE /* UInt16+Extension.swift */; };
+		336A5B17181C5E58B7FAC337F1CD4CCE /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E5B33C60DD6AEC968AAB88C9693474 /* Array+Extension.swift */; };
+		35987B98FCD2D6AF5BEABED755EC8246 /* Int+ETH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C643F25902474911AA846B5F0649D8 /* Int+ETH.swift */; };
+		3615771E73CC654F70BA5628AAA6F915 /* ABIConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75BD93C43CAE38E2D1C15252D25020 /* ABIConvertible.swift */; };
+		361850E360F46660CB822B3C22F9F5FD /* BitskiAuthenticationAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F8B5166E59DB4CC422CF71DD0F95CE /* BitskiAuthenticationAgent.swift */; };
+		36372BE1C73AE8821B37C61320FA730F /* CharacterSet+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F6511A32371C04FBE280EB4BE2029D /* CharacterSet+Hex.swift */; };
+		375016354C9AEDDED1ED9DE6D8FB18AB /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BA7032214B113B97F2679A3A14F21D /* CipherModeWorker.swift */; };
 		38685BFCFFF8F2A135D34B7307493783 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE65C5715EB5CDFB0A3BF8E65A243B23 /* Division.swift */; };
 		398D614E656FFA66513B5B3885EF8AAC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
 		39A8E5A3AB0AABB454447552A3831739 /* BitwiseOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BD8C941A189B20A24BC031F20BB375 /* BitwiseOps.swift */; };
 		39D449F216BE4DE3589E7E81B588AD75 /* Integer Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3166E42191BD5D7B635D6D79D85EF8CB /* Integer Conversion.swift */; };
-		39EA11BFD9A0DC07F4B14AD855850242 /* SolidityWrappedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611F3AF86CBE734579AA892F583B80 /* SolidityWrappedValue.swift */; };
-		39EF2A3EB0F1A6C3283918969F908E9A /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = C0AF6538391051C10B0E9CA4F4261EC9 /* scratch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A025C0384262F0B044E305F10BDD33F /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BB73690C3E709351EB81211A87B2FF /* AEAD.swift */; };
 		3A177034BF98207612FA62B7D1F07854 /* String Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CD08511C19CF57191EAB66BABD2E3B /* String Conversion.swift */; };
 		3A2C0CDE6DB45F620A0931B2F4191F92 /* OHHTTPStubsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BE2595E1803D89799189F732C0FA26 /* OHHTTPStubsSwift.swift */; };
-		3A478A651DDFD4C95EC24932B41EDB4D /* UInt+BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CD449BF26AA21F102E5485934CBD30 /* UInt+BytesRepresentable.swift */; };
-		3D409E8CBE3565FADBBA02107D42F1F0 /* Data+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A1B048611F8BED9099D09B7E1CBBEB /* Data+BytesConvertible.swift */; };
+		3AFB2113D3AB2203F8FD5B242E150C3E /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1B5AEC0AA36645E9A06973F0223BFE /* ECB.swift */; };
+		3BAFBFC194C115B6CBFF3D5C458DEA03 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1DF17A7DC85ADD2AB77212DD076A52 /* Utils.swift */; };
+		3BC093AA9FEDCFE4F6F1A57A4C5249BE /* RLPItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3D412DFC187C5D7A4A7FC9B6BA597C /* RLPItem.swift */; };
+		3CD14756937D82BB4B0AB68D9D2201AD /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FBEB0A3054416326644080E854949 /* BlockMode.swift */; };
+		3E4CFA813C8F0E702A5901B140674743 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFBD239002482DC9823DA4FB1CFB46C /* Cipher.swift */; };
 		3E659475F61FF268A9D67560CBE2F65A /* IntegerConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A07A2EE2D2FCE5CB9C9AEC58D3E0A5 /* IntegerConversion.swift */; };
-		3F25D2E5AABCA6072976E0B9AE091F93 /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 449C92465B7DF10B5B00991B70FF1CE8 /* AppAuth.framework */; };
+		3F3E715568A18AD15030BD9D42151C1D /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3A9D796036E118DFC80D097799AF56 /* UInt8+Extension.swift */; };
+		4043977D3214702A571C9B84024417E4 /* Secp256k1+CTXCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3323506B9F80BEF58C12E509F721FB /* Secp256k1+CTXCreator.swift */; };
 		40BB23A8493A986F7478AAE5ECB5302C /* OIDGrantTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 012B9AE4D5BE0AA1CF8A0D1F59A7E992 /* OIDGrantTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		414A8A6049102E11DD6EB6C520ECF7C2 /* ABIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC2663D7B4D9C4B84E0DFCF14E85908 /* ABIObject.swift */; };
+		4180A09861931E31A19FD63F8608B628 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F55D4FFC2E7B05F9DEBEA3243A6A99 /* String+Extension.swift */; };
 		41961D7908E96D891380E5CB93712C2F /* OIDAuthState.m in Sources */ = {isa = PBXBuildFile; fileRef = CE379C843A3CF887D6DB4736D97C795E /* OIDAuthState.m */; };
-		426520E978A6EAF2A93FCBFAC2CA4AAC /* RPCResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331F313EE32AB46BE05EEE033057F6E8 /* RPCResponse.swift */; };
+		429F7AFEA71FDD17827F0BD48EAD5533 /* EthereumPublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6743C01692F6313055C07E5923C0F8B /* EthereumPublicKey.swift */; };
 		42A1AB9F8D392F1618E9BE96C1C47FF7 /* OIDFieldMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 31A3CDDDE118B18E8860347C535A3D36 /* OIDFieldMapping.m */; };
+		434597CE94A5AD916BE489FD15D4775F /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = BF23EF2A652411DB5DCE502744BFE2AA /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4357E07CDCE76CE06C2D8211E6C2D505 /* SipHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B64AEE3225ACB0D037DEFAEB2B3BE3 /* SipHashable.swift */; };
 		43C5CDEF4F5DC1B6C9E0DB71392A3876 /* OIDAuthStateChangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E63F60EF9A30C17E016121B3749007F9 /* OIDAuthStateChangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43F02A1B6C8E00E65756A9A8221133A7 /* RLPDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295136276F90DC4E52755DAAB0C4D24C /* RLPDecoder.swift */; };
+		445BA964127D1DBB12E744B71092B60B /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A278C159C12C8C0950797CEFC1C47FA /* CryptoSwift-dummy.m */; };
+		4495F465597EC349E50230BCE66F8943 /* BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCD50642F1A5D0AF72FCBB94290C398 /* BytesConvertible.swift */; };
 		4507FE4C3F3B1D848D676D5E40B34AD2 /* BigInt.swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B03619170E952239342C4429BED514E4 /* BigInt.swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		47836D25B89AC48D8AB5992CBB5B365C /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A305D5B44C5E329F4DCD01944F8DF2F /* ChaCha20.swift */; };
-		486C22820CEB9EAB51C638C6899E2148 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C14499F89076C2F2D82E055C4B4CB1B2 /* field_10x26_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46A5A65875F55A885F8968FF50FC7178 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7CE98D53E529B2DA41AD5C873AE580 /* HKDF.swift */; };
+		4857D385DD120764FA5B577D9640EB68 /* EthereumQuantityTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8BA3F73BE6ECBCF2D385AB1C68A60B /* EthereumQuantityTag.swift */; };
 		490E1625EAED3B60740E78E89C6ED202 /* OHHTTPStubs+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = C2E7DCDABBCCE39BF5A4149F10A9B3B1 /* OHHTTPStubs+NSURLSessionConfiguration.m */; };
 		49C4445F1009797B0F2FF53AE50F57B6 /* PrimeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417DF7829B63B58F6372326ECA72984E /* PrimeTest.swift */; };
-		49FBB097C4780D7DBA631D9715A6290B /* Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15389599F303AEC177A5CF1FC1E9D96 /* Web3.swift */; };
-		4B45BA8AC01CB904F24C1B80C3A964E2 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40F3984B105E8CF88E9803A08A1197A /* Bit.swift */; };
-		4BB9B58B60F9D80BBBEC3D1A0E79F9DC /* eckey.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AFD8A594AA00F81AF7E07854B30EB0 /* eckey.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4C072D6C110B0C6F38B042C320843EAA /* Exports+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0896037BAFFF5EE1756D8C7A8D7E4C64 /* Exports+PromiseKit.swift */; };
-		4C522E56B6C8248F37BDAD9BA9B96BCF /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F108A5759210EC31BA6E607EE36289 /* ecdsa.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4C687F9C2B2759CE0F59F837C4313C52 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5735A353C79AA4280DDCCA3684C5FA85 /* Poly1305.swift */; };
+		4A2A362D21AE82D64E26EFD05F9C390A /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDD585F5A5B062C9D6CCE5C11749556 /* Authenticator.swift */; };
+		4A9E9384FE146B5028DDE16968A49094 /* UnsignedInteger+Shifting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8B7CA7D898BDD0FB4BF26F3D2E5627 /* UnsignedInteger+Shifting.swift */; };
+		4B5CA4344BEEE029807C2E56403526C2 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 063393ACE9B5BF415EE22C147653A250 /* after.m */; };
+		4C9ACB4F588DE273FA2A14180A7CEAD3 /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 10F82FE1342A785F37DCAE85F85BD013 /* eckey_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4D223879A79D718F0CBD39AA7365A18E /* FloatingPointConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FC0D901E2BB620C5B123D072CBACA /* FloatingPointConversion.swift */; };
-		4E16E8A8A178782609B6772035074175 /* String+HexBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDA254C0D200D9E98DDA0D36B320308 /* String+HexBytes.swift */; };
-		4F5A55E0FABE61997E022A8600A2A7AD /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE3BC3DD777C3A6E537B164356B371 /* Cryptor.swift */; };
-		50205BFBB4BB37282683C1746E491944 /* Web3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E5C082DB7E8053C86AA5F32A64ED02 /* Web3.framework */; };
-		50A357206654359639F6488C3C9641B6 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E312130B41D73E89A99467B044140F3C /* StreamEncryptor.swift */; };
-		50C174FA26D8BE66019428486C6E306D /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51E3BC1ADE8A0A20D135288987BB364 /* BlockCipher.swift */; };
-		5143828B7AAA1C28D48CBB1EC251814A /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 98480325FFD3F70E26CB8ACD00A93DF4 /* field_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		51774FE7C5E5A29A667599BD4312C01E /* BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCD50642F1A5D0AF72FCBB94290C398 /* BytesConvertible.swift */; };
+		4D33E5DB9C123323BE2BC58D452617F3 /* scalar_8x32_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6D766B5B9AC66E08AAC62F16621BCF /* scalar_8x32_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4DBA4353F71DD104BF985317651CCE6E /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBAC14EE91E5270109D8891CCBA9717 /* num.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4EDC274BD69EBE21A56361E7725960D0 /* EthereumData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA3DD5E2FA9D3A93FAADDD08FE4FC9 /* EthereumData.swift */; };
+		4F307F24530BD02A2141315282860F25 /* Web3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E5C082DB7E8053C86AA5F32A64ED02 /* Web3.framework */; };
 		53075748A8F4AB36DEA4BF24122DB3B0 /* Prime Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5645CE70AA5D95B5567857DFBE5164 /* Prime Test.swift */; };
+		531C361FC01431E96CA149F661D2700B /* EthereumValueConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225277D0DEC1B786BFB9C68A6BD06143 /* EthereumValueConvertible.swift */; };
+		534360E4753A79F8B95AAEF90DBFC38B /* SolidityType+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE60B0DC2F679ECBEEB3C41F648D70 /* SolidityType+Codable.swift */; };
+		5351D44D095E0F9861284DE914417D4B /* Web3-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1EE4646F089C6B16110296FB283255 /* Web3-dummy.m */; };
+		5368ED7E926BF139A27934EB2156FD1F /* field_5x52.h in Headers */ = {isa = PBXBuildFile; fileRef = A677727BC17C6EE4E46BF3A3C9F32077 /* field_5x52.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		539EAC2ECC54398F72170F80DE520211 /* OIDExternalUserAgentIOSCustomBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = CC79FDCF745DD47B5EA7C5BC02B9DCB9 /* OIDExternalUserAgentIOSCustomBrowser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53D16A0A6BEC0016A1C0CED3111B917C /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5F4C7F574C962F0209AC5FA6CD614 /* AEADChaCha20Poly1305.swift */; };
 		541F083F3F3EF1EA19D69F86D2B4E15D /* OIDScopeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 90D0530DFC23C37AF14144414981CBB7 /* OIDScopeUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		549A0BBB0B16BC2313CCEF852385B2A7 /* ERC165.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD686313CD800170FA82E8A9DD679FC /* ERC165.swift */; };
-		54C73FB21832C01789D0AB8A3F68DFD5 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E6F443CDF6003B1E2333CD1DFCA80 /* CTR.swift */; };
+		543036112C1E2C00D483522B8A7B37C6 /* BitskiTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150DA45616AFAB75349DAD331B95A9E5 /* BitskiTransaction.swift */; };
+		55197F1B539488C4D78D8897F42A81F4 /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAC0799A54D45463DB2E5809AC2E20A /* CBC.swift */; };
 		557A4CDBFC1A9E5B42DCBF93593A31AD /* OIDExternalUserAgentIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 449BB9070AC5DEE06845E24187A9DC4A /* OIDExternalUserAgentIOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55855BB64578CCDF18D6DFE02D77851A /* Bytes+SecureRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFB9283FB49B52A0318148A2686906 /* Bytes+SecureRandom.swift */; };
 		569585A743D48C7CEE8A74BEBA8164C1 /* SipHash-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3891111ADEE1B61BD2CDC67521DBCC /* SipHash-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		57AFC27629FCB00EBFCE97DB601C3932 /* EthereumQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAECE911EB4E6835E21EF83B1AC4DC5 /* EthereumQuantity.swift */; };
+		56DA998A73C15ED90F613FFBB80D3004 /* Web3Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C858CFECDC67959EEE208CE49FE74143 /* Web3Provider.swift */; };
+		5791309BB74CC069EB3E3940744D138D /* Bytes+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6503492B80CDB4B92129558A2D45A4 /* Bytes+UInt.swift */; };
 		57C120528D619C758901ACAE2C512116 /* OIDAuthorizationService+IOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 9258685EBDD6CE3289D3C9188C36CA75 /* OIDAuthorizationService+IOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5811C6E426D788181C5A13DB9DB50A21 /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = DD53731F5D4ED510F0208D7FE75356AE /* secp256k1.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		585FCD009CF3091870A66293F12BF3BD /* RLPItemConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EC10FF6294C038EFAA98FEDEF0F4A0 /* RLPItemConvertible.swift */; };
-		58689F22E7DF5C8F21DA6D37FFA3DC04 /* SolidityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4F345813E8A26C9E4F70E8F93BDEAB /* SolidityEvent.swift */; };
 		58ADB89815B24338732718F731BFB4D4 /* OIDIDToken.h in Headers */ = {isa = PBXBuildFile; fileRef = DCB2E7BD58F0347EE7CF78B81B5422C8 /* OIDIDToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A05AEE1333FBB490B5DEFEB83C7C4DB /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75A651660B17D786A5C0233DDFEEE0D /* UInt64+Extension.swift */; };
+		5A104832A4A49AD1B371F7E9957811BA /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03063B73D23A545A0F6A24D58502B52C /* Int+Extension.swift */; };
+		5A425F5A0DB513EDD83E35739A42A78A /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51E3BC1ADE8A0A20D135288987BB364 /* BlockCipher.swift */; };
 		5AA554AB3AE78BA7EF9434D36C7BBAA0 /* OHPathHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 41A1090B90FB7A5CF6399B5C7434533F /* OHPathHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5B11A4362B4B72299B2BEA7DEE9D7574 /* SipHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7ED01BBE3E6C8DD37E18A2D8B89CCC /* SipHasher.swift */; };
-		5BD5B97AAD25818710D0B8BC0A052D68 /* SolidityTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F67EF55D3D0C8048D4D0968662371A /* SolidityTuple.swift */; };
-		5C28077523288FF969FFAFF30D7264FE /* Web3Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C858CFECDC67959EEE208CE49FE74143 /* Web3Provider.swift */; };
-		5C9BC6B290CED31877EB16BFADB255B9 /* ABIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC2663D7B4D9C4B84E0DFCF14E85908 /* ABIObject.swift */; };
+		5C773910076BFE172B5DB0C794510C15 /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA3AFA7A34EA7C402817807A481AE93 /* secp256k1_recovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D48259EEFA1A1957656009EBA8EB99F /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0030293708F3272A947584025C8C4D2 /* GCM.swift */; };
+		5DE25363C9D441C14168F8EA038BDABF /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFDEDB8C756357CDD0779A61721838 /* Catchable.swift */; };
+		5E2DEB1A40E8737F4CCE26A5768A63B0 /* RLPItemConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EC10FF6294C038EFAA98FEDEF0F4A0 /* RLPItemConvertible.swift */; };
+		5E40E4C05EED1C72DEC3B76E6C3E3E27 /* SolidityInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DCBBE4F4D5D555E4E14C39F93D6756 /* SolidityInvocation.swift */; };
+		5ECEFD24F085A79C5C36DB97D58E3F4B /* lax_der_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 21F11BBF550D7AC9B8B673093C7B2633 /* lax_der_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5EF5ECC848D0CF8B6FA7D3326581816C /* OIDURLSessionProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E63BA7BBA2D4DCA68FFF12E269C115EA /* OIDURLSessionProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5F8B2B86698462D8D60E6536E113B900 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5316F6915675EB5CE9BE363FFF9C17BD /* Data+Extension.swift */; };
-		6070B29B30D23955214EF666F7CAAFA8 /* EthereumPublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6743C01692F6313055C07E5923C0F8B /* EthereumPublicKey.swift */; };
-		611B7667C6BCCA6B4FD897A28F5B7EFB /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D52E3CA20C05D922E35438AF7785D3F7 /* scalar_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5F1112C1E499B15A44943EA38F826C1D /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = FF601A4C09C272A73917799B6E52EA86 /* scalar_low.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5F548F0F585C5F74E85A1E83A6AB104C /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEDE6AA7DDDD2767E5F87BD9FAA2F94 /* ecdsa_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		61200003D737AAB21747C4C74C8C75F0 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B328DA7623921051280C891F93ACC20 /* Codable.swift */; };
-		6126CF793DAFD5059F80457AB0FF4AEF /* lax_der_privatekey_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ECA1CA409953AC336127995169C7DE3 /* lax_der_privatekey_parsing.c */; };
-		628F1DC550FD5823D18A1F7E816FFB7A /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A74A4AC42DDE4E06563017906E62CBE /* UInt16+Extension.swift */; };
-		62C2655E5B76BEAC3C60BA108BD58A71 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 31C4AFAA24951C57C70CE58986095557 /* scalar_8x32.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6145F30BE46E23C27C013ABF5A962B39 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B0FCAE10440C4D78EFF352455FFFED /* Resolver.swift */; };
+		6325DFB73A010D122A86099739D8C82A /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4953586D8E95AE42DE002C5E6CBF90B /* BigInt.framework */; };
 		63DC3E69AE41B18A941F60CD7C58850F /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4428877D94A720B91367D81D014FAD6 /* BigInt.swift */; };
 		647FD8B042550DEDF2031D30702A2D19 /* Pods-Bitski_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 406ADD96DAF8931C73674189BFF4D0EC /* Pods-Bitski_Example-dummy.m */; };
-		6616265F933A818263B395286416B2F5 /* Bitski+OIDAuthStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B42BE132EC3117F12904FC597FE6DD8 /* Bitski+OIDAuthStateDelegate.swift */; };
+		64E1B74797253469C9A63C9CF17F5065 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = E46CA322B4697FB9F8E8C9AA0B134E9F /* secp256k1.c */; };
+		6699BF9AEA7A406C2E58D79452814D33 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A39A282357F7B73C85A2131A947F9EB /* Promise.swift */; };
+		66CA386C7DA3864570E5591BFC12AE8B /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207EFF6805B6AA69AF0F173DEEFCE081 /* hang.swift */; };
 		66F0C49FAC8735CDB6B8477565A72971 /* AppAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 68994D064D49A4C2C46E13B38559A1DA /* AppAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66FC4CE2B8BA53F6EAF6DF7A5EADD69C /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EA121AD0B151E6AF4B132A14EF6E70 /* PBKDF2.swift */; };
-		675CE3E33C401D5BD8ADD7DCC9C5048A /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 30C79749C116CC9EE01C72B33FE931A2 /* field_5x52_asm_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		67C03F907B5AFF1F426C5B6406FB61F8 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0281C90391425FA81092F4AB5D587232 /* Digest.swift */; };
+		67099506CE0401DDE83596612642CFCD /* secp256k1.h in Headers */ = {isa = PBXBuildFile; fileRef = DD53731F5D4ED510F0208D7FE75356AE /* secp256k1.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67B4E5D9D0D90A8FFDF0232F3170D910 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237A42E4E4ED1BFF2BD2776F4FD61B5B /* BlockDecryptor.swift */; };
+		68A665D24370B2F6B7B137A87EB08386 /* hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 79CCF8F943E860BD647634D6E6592D55 /* hash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		68CEBE7F556ACE5A1A3D1B3F5640B07F /* OIDAuthorizationService+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 80AC92FDB1F57DB4CBC53B5AB3594A2A /* OIDAuthorizationService+IOS.m */; };
-		6959696CC5ADA52DBB3CB6E428811C69 /* ERC20.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D188A981B5F72A0CFA327C792343BA /* ERC20.swift */; };
+		6A97875F3AA511A691E27409EFB6467F /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E5B7E2B4FA94715584D1735FD4238 /* hang.m */; };
 		6A99A263F46D36E00ACD3422C3FB5D8B /* Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76545A29E58982D75671F7C0A3915A06 /* Shifts.swift */; };
-		6C173B2024ED0B256024576080E1DF0C /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBAC14EE91E5270109D8891CCBA9717 /* num.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6B47D63C23394DC11FCFD76E70407A15 /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CA69EF61A20E49D5A0306C97BF007F91 /* scratch_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6C31F243D76FD129B39713AE5978F4B9 /* ERC165.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD686313CD800170FA82E8A9DD679FC /* ERC165.swift */; };
+		6D07B79F0E8678DDF2F6CE193E688092 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
 		6DA8FE878639DDFBCBC592EA59768012 /* OIDAuthorizationResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = A73636A971FA62238B64B687B0352F3A /* OIDAuthorizationResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6DDB95270FCE8B4816B2ABAF86D082A3 /* OIDTokenRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B484A2A110BB713A676F6DD88A1F6246 /* OIDTokenRequest.m */; };
-		6E5A62AC7A905A8538511861BD68E68D /* BitskiTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B02D530DFE0FD7924387B16EA5A70D9 /* BitskiTransaction.swift */; };
 		6E6C03F442643C561464C6FCF34878A9 /* OIDServiceConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9761412F801A9A05113A62A02B5ADEAD /* OIDServiceConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		700A7BFC41F46D6DE2864CE26B27E5E7 /* EthereumTransactionObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55549D1729BB0CB8854AF2678A87E526 /* EthereumTransactionObject.swift */; };
+		6ECD10DDA988EE63C341D74AAD0CF6EA /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85213F3EB385B5D2F930BDB126504B56 /* Error.swift */; };
+		6F36D683B6930474E864129F349CCDCD /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682E6F443CDF6003B1E2333CD1DFCA80 /* CTR.swift */; };
 		708CB4E44BF5F4998FD99F004F1CFDA0 /* OIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = E70CE9F382E66AD45C88B31DA948870F /* OIDError.m */; };
+		73AF1E441052B42D52216B17772499BD /* secp256k1_main.h in Headers */ = {isa = PBXBuildFile; fileRef = C8E6E703E37C38FF7C75D7A02305AC01 /* secp256k1_main.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		73C3515308077FCF1D6935B314DA8DA0 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB170ADAE77E9219B2050F28131F194E /* BlockModeOptions.swift */; };
 		74838FF68C9AB00BDCAEF278CA5C8231 /* OIDRegistrationResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = C7FC4D96CEB9EC7220A7B29F8B4DC42A /* OIDRegistrationResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7514D464CF7CAE125BFD86B720448DEF /* ABIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF1AC965E53A1A13762320B26C7435 /* ABIEncoder.swift */; };
 		755438020FE59AFAE8A3A6EF994C7280 /* AppAuth-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FFEFED9A3D9194C711BFFD36477FBA3 /* AppAuth-dummy.m */; };
-		755B5BBD15D3BC3102FC290C5F7DD378 /* Int+ETH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C643F25902474911AA846B5F0649D8 /* Int+ETH.swift */; };
-		78AB55627E566025AAD58D4AC0BDC0D6 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40CFE54BE974C7318640767F792BD76 /* PKCS7Padding.swift */; };
-		79E0636BE13900EEF655C6831232100F /* secp256k1_main.h in Headers */ = {isa = PBXBuildFile; fileRef = C8E6E703E37C38FF7C75D7A02305AC01 /* secp256k1_main.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7A0BB9B10E4CE0F6F2BE4038C166AF38 /* UnsignedInteger+Shifting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8B7CA7D898BDD0FB4BF26F3D2E5627 /* UnsignedInteger+Shifting.swift */; };
-		7A884BB6E5F56BE5D764781DF20CAEB1 /* scratch_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = CA69EF61A20E49D5A0306C97BF007F91 /* scratch_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		758479D87828CCCB979BC01698635144 /* RLPDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295136276F90DC4E52755DAAB0C4D24C /* RLPDecoder.swift */; };
+		76AA8190417BA4E1824E0DD4BA573D0A /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FBA94C56F7D060E4F68E9EA730A146F /* ecmult_gen_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		774FB2CB790F0755BC1375BDFA93CB6B /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C986EC32BB4E41608DE43E1A0406A /* RandomBytesSequence.swift */; };
+		77751EB9903BA7F3A44398795BC84BD6 /* UnsignedInteger+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2805C97988104C37686896937EED0EF9 /* UnsignedInteger+BytesConvertible.swift */; };
+		77C8807407F338F58B4A822CB02344B6 /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B456F53FA02293DC9D236966D30B84D /* num_gmp_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		786F2B5B0076333CAB6B602EFF270A84 /* field_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 98480325FFD3F70E26CB8ACD00A93DF4 /* field_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7A19FB86B09C1E398AF8205C5238C16D /* Bitski+OIDAuthStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C802B914EAAA8849AAA140FDE3CF87 /* Bitski+OIDAuthStateDelegate.swift */; };
+		7AF2DFACE54B2DD224D58A48F1D9F6D7 /* Bitski-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AD16346145DE6DE954E144C7788AEAF /* Bitski-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B07D7A98E27412CCAE7AE28AD1040BA /* OIDRegistrationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D2BD74F1A327BC625EF3C82F47B648 /* OIDRegistrationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B0F983FB60E2CAD50BFD7155F78EBF8 /* OIDScopes.m in Sources */ = {isa = PBXBuildFile; fileRef = 39BA8AAD9FCA1E57010637DE1E93D814 /* OIDScopes.m */; };
-		7B9DA4277987DC9C317187392E021CD9 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359098AD4B7E7B8388E033B6CB600264 /* Operators.swift */; };
-		7BC8016CA08A24BC512BC7B7751FDC6D /* eckey_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 10F82FE1342A785F37DCAE85F85BD013 /* eckey_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B7D943CE82CBB3E69336801C1C48B2B /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2922FA7AB33ABFC439CA8DF0158798 /* PKCS5.swift */; };
 		7BF7B5E46E8DBF32B8780FDB25620247 /* BigInt-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE583903970FCA83ABB6B9437406F42 /* BigInt-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C7ACDA388046B29BDEF604BD6115A0D /* BigUInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B247F9697A5BACF9DDCC2FA5CF0711B8 /* BigUInt.swift */; };
-		7D7732B5130154B5115DACC51D2AC0F4 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F386159D9CA220367D442FD3B59D3642 /* Updatable.swift */; };
-		7DB51DDBA6CF6681C510380E217A9086 /* RPCRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143A30748D182578831D8985F9A39664 /* RPCRequest.swift */; };
-		7DD91953ECF377676FA206E5F717B048 /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4CFD6275662ABEB5EE36C294962736 /* group.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7E5498982F0C458C93228378BFD34767 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C986EC32BB4E41608DE43E1A0406A /* RandomBytesSequence.swift */; };
+		7CBF40FE5E5C23F19CD7EF243EF19D02 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4202E42DE40D5719E2E981781DE17FEA /* Generics.swift */; };
+		7D5CC7759616EFFAED39EA7071400074 /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8495C760351C39933C94A4F94DAAC06D /* scalar_low_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7DA618CA36267C97083625E7216618BF /* EthereumAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00AA9812ECE66B4E0F9A7C79BD8B5BA /* EthereumAddress.swift */; };
 		7EA0E093A38FF34E60CF39A864247DE1 /* OIDTokenUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = ACFA693D171C3E31E0070BBF96E13822 /* OIDTokenUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F069C86D932A8C1988B7C734349D24E /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBBF4F4A7B4EE050AA9ED13E11B1C5E /* join.m */; };
 		7FA73452440A65B3986F48D6565DE363 /* Exponentiation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AD42029E4580E161B5A1A52CD2F30C /* Exponentiation.swift */; };
+		7FB49EEBAB04E31C2C78B829EE6C5C3D /* RPCResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331F313EE32AB46BE05EEE033057F6E8 /* RPCResponse.swift */; };
 		804B544EF6FB224913D8F1F53D405239 /* Pods-Bitski_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 11548A2A342540A4BB1A8C7356E1C3C7 /* Pods-Bitski_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		80CF41B2091568F85EDB1FF392293944 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03063B73D23A545A0F6A24D58502B52C /* Int+Extension.swift */; };
-		81787F536B6E1ABE2D332C77D175EAB7 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = E46CA322B4697FB9F8E8C9AA0B134E9F /* secp256k1.c */; };
 		8218AFB5E4C8D07F378118AD93DB8632 /* OHHTTPStubsMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = E85433A7935DE03173370D5F209333C5 /* OHHTTPStubsMethodSwizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		83168942A1CF269D8EAA4BBAC1BF2A73 /* EthereumPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515D266F506E3B808CC2B9113C333FA8 /* EthereumPrivateKey.swift */; };
-		83484AFEC841E21DCF7F3A6FF41A301E /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7DE5847361FFD6D6AD0FADDC6F65 /* AES.Cryptors.swift */; };
-		837B7F6314D5DFA602FE72C68CF7D6A2 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85128C5230DFA05AAFF5803A752C5CD /* SHA3.swift */; };
-		8422E41558883335D64187687467A39D /* secp256k1_recovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA3AFA7A34EA7C402817807A481AE93 /* secp256k1_recovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87914C260C2F9CB463EDC36A150BEA63 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = B8BEE8189473E2E79B1236CD485BDDB6 /* util.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		88BB6556CD38495B2AE8EA2F48847DFE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		890BB3FF0EA7E07F6842B3FB60B95D9D /* ecdsa_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEDE6AA7DDDD2767E5F87BD9FAA2F94 /* ecdsa_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8927A63192F5A5442441AE3ACA4E2FCF /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF15AFFD5CCE3F2F61C17732675AAE96 /* SHA2.swift */; };
-		897FA17378D7494989271A43762C1DF2 /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = B55E1047B4ADC508F4478DBEFB5150FA /* ecmult_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		83068C346B171BA7D7A7A400CD33F340 /* Eth+Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B747871EAD46685D43E5B4F6CF2029 /* Eth+Contract.swift */; };
+		83747708D3CF5F1049AE1D3CFCCE9292 /* secp256k1-config.h in Headers */ = {isa = PBXBuildFile; fileRef = E73D4288481564885C41CFCA21D6066F /* secp256k1-config.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		83DAA842390B030CBCDD4D75A947C77C /* ecmult_const.h in Headers */ = {isa = PBXBuildFile; fileRef = 288BECCA915ADBE5BF22DB25E1F60D69 /* ecmult_const.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		856D02B5C3E2E1B268FA1045DCE31B5B /* lax_der_privatekey_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2D731059EF1F76890764E18F4F5445 /* lax_der_privatekey_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8607AEF12677E2ADF261C4256404D10B /* Exports+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0896037BAFFF5EE1756D8C7A8D7E4C64 /* Exports+PromiseKit.swift */; };
+		863A7D13F3D2347C84B20B2127AA4054 /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BEE97874578880A7FBFA5774CBCEC5A /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8778CA3E7C8A1A7303E8BADFAB4493F2 /* group.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4CFD6275662ABEB5EE36C294962736 /* group.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		878D4B989AE8C34ABD6388047D533F6B /* lax_der_privatekey_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ECA1CA409953AC336127995169C7DE3 /* lax_der_privatekey_parsing.c */; };
+		879EE6FC2956AAB1CBF2130CCD14106D /* BitskiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6BF26B7D7741674D91B7B94EED1983 /* BitskiProvider.swift */; };
+		87ABD51A0DBDCD9983CA2C24B8C50CA3 /* UInt+BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CD449BF26AA21F102E5485934CBD30 /* UInt+BytesRepresentable.swift */; };
+		88191F068E037C91A0C05BA5B5070118 /* Bytes+SecureRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFB9283FB49B52A0318148A2686906 /* Bytes+SecureRandom.swift */; };
+		895D6136D4B8B81B663CD4BB0140ADC1 /* SolidityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4F345813E8A26C9E4F70E8F93BDEAB /* SolidityEvent.swift */; };
+		8990B238003939FF31B08EAEE57C196D /* ecdsa.h in Headers */ = {isa = PBXBuildFile; fileRef = F5F108A5759210EC31BA6E607EE36289 /* ecdsa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		89AEC4C946F9EE1F3BA8BF6496E5329B /* scratch.h in Headers */ = {isa = PBXBuildFile; fileRef = C0AF6538391051C10B0E9CA4F4261EC9 /* scratch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		89B37EE882CFA371CEBC5F66FF4A0AC4 /* OIDAuthState+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E0B78F9B0FB3554B72387DA2CDAFB3D /* OIDAuthState+IOS.m */; };
-		89EDED95B564D99D1D729A600F4424C3 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 239D97CB5AAE0F93697D9F61C7390D78 /* when.m */; };
 		89F786BAAFFF6283C9F39B12A6C9CADC /* OIDResponseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = C404A9837419575DB173601AC34E950D /* OIDResponseTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A0E32BEECD1EFB5244FE20A2137B45F /* scalar_low.h in Headers */ = {isa = PBXBuildFile; fileRef = FF601A4C09C272A73917799B6E52EA86 /* scalar_low.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8A57A3966AA34E56A3FC75027C916EE8 /* Types+EthereumValueConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B748F74D7CB3BB28E46690DBCEB7933 /* Types+EthereumValueConvertible.swift */; };
+		8A26E5289978759034C09061CC82427D /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536525D7183A9515ADA1A18C70B56E48 /* Rabbit.swift */; };
+		8A4DD7590DD5110BA6BB0CBFA842A506 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE3BC3DD777C3A6E537B164356B371 /* Cryptor.swift */; };
 		8B202C6C56EDA7B9B28BB32FAB46CA2D /* OIDTokenUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F3F4927693CE47220FE7288267569 /* OIDTokenUtilities.m */; };
+		8BAA35F5B79E143250B61E4B63C1EAC8 /* EthereumSyncStatusObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03EFCD69DF7C93BDF9E24A14B66FE0C /* EthereumSyncStatusObject.swift */; };
 		8C1BD588D62443A70B0CFD5FE3AA9ED5 /* OIDExternalUserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 02EB25880886548D6EC00D8B21644C4E /* OIDExternalUserAgent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8D8CF0B18342D97199DF421D8BA1E9BB /* Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD1D5324929DF1E01F618536307A6D1 /* Shifts.swift */; };
+		8E5A5FC32B7F5F08BC8F3A2A44FC203D /* Web3HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4505F79FDF6D00830D21BA8B4EBE9D /* Web3HttpProvider.swift */; };
+		8F14B9D797267F4856D6F2B195C0CE57 /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 72793E0694B634AD8C12A8867C75A2AD /* race.m */; };
+		8F4724F3D67B47E4577EB55E8A442FDF /* ContractPromiseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580C3523D8A539AD350BC5B670F9F7A1 /* ContractPromiseExtensions.swift */; };
+		906AD94C6A83D577D897C8EFDDC92369 /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 756D9F83FF53C4F41C1813307A1ADC4C /* num_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		908DB48E8066721EACB8520E3687D5AA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		90BADA1F4DE41BB89B9E03095DE609EE /* EthereumQuantityTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8BA3F73BE6ECBCF2D385AB1C68A60B /* EthereumQuantityTag.swift */; };
-		916BA37A11E16E10860BF0C425C15947 /* Web3+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858045962765091627D71EC66D7528A3 /* Web3+PromiseKit.swift */; };
+		915276A16E912255430E1A602CBD94EA /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0D58EC06A66A67DC90E8BCED8A955D /* field_10x26.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9213FA46FD9BE461EF52741BE3AAFA10 /* RandomUInt64.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4477BDBEB5B426B896B852840DE007C /* RandomUInt64.swift */; };
-		930F86D57C3604C7456592DF97C1E219 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0880E55B15B79D25BA7B4B84D6ED4F1 /* firstly.swift */; };
+		92F40686E055626CE106EE9C999F5109 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F386159D9CA220367D442FD3B59D3642 /* Updatable.swift */; };
 		9312484466BA82F00825CDF8DC277883 /* OIDErrorUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 2365204D135DC8A8E2A1F72951731D1D /* OIDErrorUtilities.m */; };
 		9318BA4898BEF593EF306D3D4EC0C96F /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5537CAE630753585F4EAF3239F98C6 /* Random.swift */; };
-		937BBB138480DC078E0DA2ECD0E2A113 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7CE98D53E529B2DA41AD5C873AE580 /* HKDF.swift */; };
 		947227D76F60BCEE8FD75BD8B21A1364 /* Pods-Bitski_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1761BE4AA4879151707A4EC0B13527CE /* Pods-Bitski_Tests-dummy.m */; };
-		958A6C22705FDA14D25E9C38BC1EBADE /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA8ABD25A3D37260D678C0998267DDA /* PKCS7.swift */; };
-		95D02365912094B13DB4595A3DDF88A4 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE91614B15EA54E9E57E0017839A3F9 /* CMAC.swift */; };
-		9620B2E95B7EE57907C511E8A238BF2A /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E5B33C60DD6AEC968AAB88C9693474 /* Array+Extension.swift */; };
-		96ADF4DEC74E10AA0AA26E26C8813C14 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5F4C7F574C962F0209AC5FA6CD614 /* AEADChaCha20Poly1305.swift */; };
-		96FA3D383E64FCB53CEC2E315AB3DF2B /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF04633DBC928481877E2EEF52F6D4C5 /* PBKDF1.swift */; };
-		9754F1A4330D52490B20A9DC766660EB /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = E014DC54C758893D25AB553171CE5571 /* CFB.swift */; };
-		97C41BA203E770B32FD17FBECBCF7400 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB1B28906E3D399C3F613061BC69621 /* ChaCha20+Foundation.swift */; };
-		9888671AAE54DB9D95F773F8C081AF14 /* num_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 756D9F83FF53C4F41C1813307A1ADC4C /* num_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		9895560B2521FF2E03A5884D6428861A /* BigUInt+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A246FFFEB5091652A59BFC748FB78 /* BigUInt+BytesConvertible.swift */; };
-		990AA208CE94EE55510AEA01CC77E00A /* ERC721.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A3008CCE1B526D91E98C5C5633130 /* ERC721.swift */; };
-		99D3FEB7D737D4A8747CE166216696ED /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = BF23EF2A652411DB5DCE502744BFE2AA /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A1BCFB8978227A5960058DEF3764A37 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FBEB0A3054416326644080E854949 /* BlockMode.swift */; };
-		9AC2B8A7BBEBC610FCE7627AF91036B9 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B14A1B038C564FA60D23A57A8A9E03C8 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94CE0210B79F52BDB6FDB1A5500FB369 /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C6C10C4872E85827C103893A7B8EE8E8 /* field_5x52_int128_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9843BC636C1499F7EE073449F89CD182 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FAE3DEC5A9E4A976CD76C7BD651AE9 /* AnyPromise.swift */; };
+		99DA3B5405D65BE89B1348F69C245909 /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695FA613ADA67889EF9B4A2C355DE7F7 /* Rabbit+Foundation.swift */; };
+		9A3C2BF9121D57065769B944C900F10C /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC5E095CCF532FAE8120CC5F04ECA20 /* Collection+Extension.swift */; };
 		9B04407DFD3F92FF013BB02ADF2D7985 /* SipHash-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A56B53CEC5425498E7B02EE602C89560 /* SipHash-dummy.m */; };
-		9C0871AF3EBBAF16A1855D05EB598734 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0343D0A95F5B8D1560D9132D482C810 /* OFB.swift */; };
-		9C462A4E44F9CA0EBDA70D1A2BAF5C8A /* BitskiAuthenticationAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1AE722A293D5DFE5504D1A78B9664C /* BitskiAuthenticationAgent.swift */; };
-		9CC4C48EFC72BD7CC33B396F2BFC61A4 /* PromiseKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BEE97874578880A7FBFA5774CBCEC5A /* PromiseKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D52D4A208808AA539E3C694DE26149C /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC5E095CCF532FAE8120CC5F04ECA20 /* Collection+Extension.swift */; };
+		9C3A16A45708009C629DAEB820175700 /* SolidityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6034570FFE463994B5AAB8AEDEB3C53 /* SolidityType.swift */; };
+		9C6D4FEE82AC10C7C0C1611A16077A0F /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56000A67F11F36A34BFB44BA71DFEAE /* Array+Foundation.swift */; };
+		9CB45020FBC9342F65E839F1A8B2AD4A /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC023AB111D24FEEDBFA70A10D3D7D2 /* scalar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9D3C78CC6D0F9D72FD8EC128EE21EDE0 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF04633DBC928481877E2EEF52F6D4C5 /* PBKDF1.swift */; };
 		9D96F472DF1CBF7DAC29B03EE702CB81 /* OHHTTPStubsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 371BA170A87860F99873A74B3A91FF4B /* OHHTTPStubsResponse.m */; };
 		9F882C0FB4AA408854857E533402C38F /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79EEC3C012C0BA68CA3E7ACC6B9184BD /* SipHash.framework */; };
-		9FFF88FC0543C328C072F53D9F98607B /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F289D79DE695B57E7C08BC9C746D0F /* group_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A0037BE6F03939AAF1CAB8B365018F82 /* OIDTokenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = AE53BF1FA1DF83E0F1062390E72EB8F4 /* OIDTokenRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A06612D0E90FB172D6002D74A00FBD89 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EF555E31A9B6800583AFBC92F5AFA2 /* GCD.swift */; };
-		A09CC4A410B6F61AB6840D8AFB63D954 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 55371D0B7FCAB1177169AE5AE1CB9E2B /* dispatch_promise.m */; };
-		A0DE99F7F144CF9EB6879840CF79A8D9 /* Exports+Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608427808F04683EE5DBF3804B97333D /* Exports+Web3.swift */; };
-		A0EC6EBE9812EA35E02188A1899BD5C5 /* CharacterSet+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F6511A32371C04FBE280EB4BE2029D /* CharacterSet+Hex.swift */; };
-		A1DD426239D14486BBC4A0426FD04623 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3547644B575AC1B76010C9B58574A6FE /* Thenable.swift */; };
-		A22D02CA4CA10154AE117C612265466C /* EthereumAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00AA9812ECE66B4E0F9A7C79BD8B5BA /* EthereumAddress.swift */; };
+		A0BD61035E7204D649A959CA76619035 /* EthereumTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C9EDBA8B04A7D69FEA3B57D75C29C4 /* EthereumTransaction.swift */; };
+		A0E0C1876F2022AD37598A4EC7AF4C4D /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7672BE439CB7CBD4248E4C837ECFB266 /* Blowfish.swift */; };
+		A10513F639862EC6DCB07368844A708E /* ERC721.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A3008CCE1B526D91E98C5C5633130 /* ERC721.swift */; };
 		A247C9B7C912F4CF71C6BE05B11EE4C6 /* OHHTTPStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C1663AF012CAF0A01169B93C4964063 /* OHHTTPStubs.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A364636620EFEEC6F0487F682EF54025 /* RLPItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3D412DFC187C5D7A4A7FC9B6BA597C /* RLPItem.swift */; };
+		A4201850D27BA5879BC1BC2D6BBE0CF7 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D247FDBD818DAE92F9A4FA69B04ACED5 /* PromiseKit.framework */; };
+		A451A148593C4FD561EEFBCFCB896712 /* EthereumBlockObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78A4EE227F0D49BB12D36FA5E5BCD02 /* EthereumBlockObject.swift */; };
 		A4FB8F02A749DB30EC5E42DD338792AF /* OIDAuthState+IOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 11FA9656BA03C8A4519651ADB30C0BB3 /* OIDAuthState+IOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A502976346010F175DD9C324353F851E /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFBD239002482DC9823DA4FB1CFB46C /* Cipher.swift */; };
-		A55C977113000C7DE24606FDC49108BA /* BitskiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEA6F642274EB51E22E6C613023AD58 /* BitskiProvider.swift */; };
 		A56C50B3D7F6656BB9B4F78AF4391F99 /* Strideable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66AB80C2113954DDD50F3D764CEDB995 /* Strideable.swift */; };
-		A5E6D5670630FB539ED0A0D13C97A9F7 /* Bytes+HexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35032FCB9E2DE326EFFDEF538AC5794 /* Bytes+HexString.swift */; };
+		A5CE09FC78F54112A8676B7F1EDDF766 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = B8BEE8189473E2E79B1236CD485BDDB6 /* util.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A6AFF826397C875D64D47A92023B43FC /* field_5x52_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 336C4CEBA01501692EBF7B59CEBA2EE1 /* field_5x52_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A6B182AD5E28282465F05D387A7AC518 /* BigUInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45D16FDC753C4894557E017F3E7387B /* BigUInt.swift */; };
 		A7623AE87498B57ED103A0A9A1161C24 /* StringConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96E8B51A500702373EAE87BD6EB26D0 /* StringConversion.swift */; };
 		A7635B8228A935694218D4B09BCA82E8 /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E59F24962E2699191425BB638B69406 /* Comparable.swift */; };
+		A76A29AA4FD2D9C2AF421E9332E1A3B3 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E9A31E6EB577BB453B0F40215C9F951 /* AnyPromise.m */; };
+		A76A4B2D2256ADF24961101ADC16866D /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B026CB700EFBBA6396E196430A0F53 /* AES.swift */; };
+		A7F81C29F6B641AE19CD86F6327EA380 /* lax_der_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = F819764598D0E1106D71B4721D67187A /* lax_der_parsing.c */; };
 		A852BF15789F1FC17BC30A3469F95062 /* OIDTokenResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DBFD82D54AA879593D8EFB1B7AF8644 /* OIDTokenResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A8A52515BBD31780079232EA2979C562 /* SolidityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6034570FFE463994B5AAB8AEDEB3C53 /* SolidityType.swift */; };
-		AA4DA496F382679305B7E4D058982582 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CB238CA77E89714BF77657CE0A5C48 /* SHA1.swift */; };
+		A9069656FC483B318C6A0C2C1773D3D1 /* scalar_8x32.h in Headers */ = {isa = PBXBuildFile; fileRef = 31C4AFAA24951C57C70CE58986095557 /* scalar_8x32.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A971DE83EA07EDE50A4169AA38CB57D4 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CB238CA77E89714BF77657CE0A5C48 /* SHA1.swift */; };
 		AA985986BB71D5898883CA6419CC0E62 /* OIDDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 796A13E087EC5172EFD3D8A681CEF799 /* OIDDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB9E8045791215137E93285EFB97B760 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 9196E0C8FEC57535701FD288D0D36DE4 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ACB8F46CCDC346C76BC63CEFBC1C1B3C /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7672BE439CB7CBD4248E4C837ECFB266 /* Blowfish.swift */; };
-		AD42F23D8B85D8B1F0477408B793A09C /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5AD28CE1DE2AB16E4DEC1318CBCEC1 /* Blowfish+Foundation.swift */; };
+		ACE0E8B60F221F58964E37095C08EE15 /* secp256k1_ec_mult_static_context.h in Headers */ = {isa = PBXBuildFile; fileRef = 56097B565B5719EBD17A627426094B58 /* secp256k1_ec_mult_static_context.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AD531C984C0C85E5674DD111292A6088 /* ABIDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D85D86975A923B27BAF210B195A12E /* ABIDecoder.swift */; };
+		AE6AF0C5CC104C668200DF0B72E4C3F2 /* SolidityWrappedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8611F3AF86CBE734579AA892F583B80 /* SolidityWrappedValue.swift */; };
 		AFABAA866D8CC75EB381292ABA83142C /* OIDGrantTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 68160E48AD6131198BD984EE7A733BFC /* OIDGrantTypes.m */; };
-		B121F66E8E96A88E09E0484B44112E15 /* secp256k1-config.h in Headers */ = {isa = PBXBuildFile; fileRef = E73D4288481564885C41CFCA21D6066F /* secp256k1-config.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B00D86DF4B5BC07933254391FD5DF509 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF135BC7454FCBBB83C9B7830920D47 /* DigestType.swift */; };
 		B182F607D8961CA7092658A75BFF52C4 /* Data Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A075D724A1D27D580A7AD5960B3155 /* Data Conversion.swift */; };
 		B184E6982BA6558B5DE72CE4626A82B3 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3FAB79E9F9B2553AFD097BD72B12EF /* Division.swift */; };
-		B213AA6DC7C874D935FA3921284F99FE /* TransactionWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3CD13AD9D05719217B0BBB2CDBECBE /* TransactionWatcher.swift */; };
-		B355097AFE18F010FB167A592F410BB5 /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0030293708F3272A947584025C8C4D2 /* GCM.swift */; };
 		B3C546DED9B2E367D79DC4AADE06A625 /* Primitive Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBF1A00590ACFC958737DF265BC6087 /* Primitive Types.swift */; };
-		B40AA005CE0553074CAA647C2320EFC4 /* lax_der_parsing.c in Sources */ = {isa = PBXBuildFile; fileRef = F819764598D0E1106D71B4721D67187A /* lax_der_parsing.c */; };
-		B42480ABE52909FD07078031AB3C5316 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDF993BC6F2063A8A4A6F70D7FF2880 /* when.swift */; };
-		B45907D850EA9043309B222A913667A8 /* EthereumTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C9EDBA8B04A7D69FEA3B57D75C29C4 /* EthereumTransaction.swift */; };
-		B487C304E4243537D941FA577E20676E /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93130B9E769D34BABDE1AAC868F983C /* Configuration.swift */; };
+		B3F6DF71A2D2F00A5175EAA1645E8A3B /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356D9DD4EF074E7BE0DCDF66030B439 /* String+FoundationExtension.swift */; };
+		B4E7FBC7A15ADD85E00A54FD329C5337 /* BigUInt+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A246FFFEB5091652A59BFC748FB78 /* BigUInt+BytesConvertible.swift */; };
 		B551E04BB84EF28C4F57BDA08719AE9C /* Square Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42638EA5309E54FB9BB5CC808EEF726 /* Square Root.swift */; };
+		B5B5DAE307B4AFD0AD77009445822ADB /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341545CED74E916909AAE4161553ED92 /* UInt128.swift */; };
+		B5E3AF2133EF46C37DA2B17862EAE75B /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0880E55B15B79D25BA7B4B84D6ED4F1 /* firstly.swift */; };
 		B5EC02E4D5554244AE6753C4E56A0EC0 /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F5DE890BE397C7BBA95889D44695AB /* OHPathHelpers.m */; };
-		B7AD102EF07B93D18EBAF81B5F8295E3 /* RandomHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C2E5997BB46C611722EBA2DBAD630D /* RandomHex.swift */; };
-		B8A5B9E3A68204781A277B1F1A415F52 /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3A9D796036E118DFC80D097799AF56 /* UInt8+Extension.swift */; };
-		B9ADF6E1C7C69A7CEC7A8005BDD0CD39 /* scalar_low_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8495C760351C39933C94A4F94DAAC06D /* scalar_low_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BA302B3AA7A75A68E37A8FDF5D7E411C /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BA7032214B113B97F2679A3A14F21D /* CipherModeWorker.swift */; };
+		B64F67AA7E9ECA7437AE45B288ADDB4D /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5AD28CE1DE2AB16E4DEC1318CBCEC1 /* Blowfish+Foundation.swift */; };
+		B72B299AF4116EFB8055D6E385FFF40F /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE91614B15EA54E9E57E0017839A3F9 /* CMAC.swift */; };
+		B8E42C48B19520FB4B251FFD281AFAEA /* secp256k1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A90896AC737FBBF78E7AF0E33EE26E54 /* secp256k1.framework */; };
+		B9E02A40EFD35EF80559FD5A5E37AD67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
 		BA8738D271DCCDF455DA1E37E71F3AC8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		BB7A703186BA3A6528C67117E86F9756 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966AD8278867B5D7B53FC09EB8534190 /* race.swift */; };
-		BC57625B6A6D23D2066ED10A4879779F /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7CA88F632C9D92DF72C2A971F67FBD /* CustomStringConvertible.swift */; };
+		BBA125DE8A8236A284BDB9B47E5558AF /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C8C35B8882B88756D97295473516F8 /* BlockEncryptor.swift */; };
+		BBE3662A330D02AB1727207B547257FD /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D75E984EE791E69A19C81A90B9765EC1 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BC2DDC0A64CFAD8BE9D340BBC3A3EC46 /* Bytes+TrimLeadingZeros.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218C6513B3261248A499DE5FD6F74BB2 /* Bytes+TrimLeadingZeros.swift */; };
 		BCCD9A06E5BD68512C7005A884A87473 /* OIDAuthorizationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = EBF246F2D0138094B0831B0708746C21 /* OIDAuthorizationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD1352B5D6C9341EEFAA2103504B5962 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D8A660D827B2C759F8C6C3B747FDA3 /* HMAC+Foundation.swift */; };
 		BD3EF4B534BABE5F9DFF411229F0B8A7 /* OIDClientMetadataParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = A75AB00FE40B52578EDC02162BABAF06 /* OIDClientMetadataParameters.m */; };
-		BDE04804C641240348DC5A4F3B1AC639 /* ecmult_gen_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FBA94C56F7D060E4F68E9EA730A146F /* ecmult_gen_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BDEF2C6E263DD07494CC51CE9D8AF7D7 /* OIDServiceDiscovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A8E198F6EC1F65FB381829B94C371FD /* OIDServiceDiscovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF7999EB96B7C7BE913716740FDEDB26 /* EthereumTransactionReceiptObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95675BF32A6FB18A4F9EE6D812F7A560 /* EthereumTransactionReceiptObject.swift */; };
-		C156C3F22A587F124D1244BB6B77BE4F /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A39A282357F7B73C85A2131A947F9EB /* Promise.swift */; };
-		C16A215C775EE299DE3C5DC34047CB7A /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE81304779F5EA312711B9C62235C48B /* CryptoSwift.framework */; };
-		C1FC067DF4C425283181E0349028FD26 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7CE9C050BCE85D5B562ACB693EA859 /* Guarantee.swift */; };
+		BFADAFD8EAC0CBDF9408EC103B78AD42 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDF993BC6F2063A8A4A6F70D7FF2880 /* when.swift */; };
+		C0025740A10C9821271C81615114D5B2 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48BF1A9DB93582728A2B5CA4EEDDA4 /* SecureBytes.swift */; };
 		C269FD974574810CE62B65643EFBCA5A /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCBD7B091889D8FF310AE9D75AB73FE /* Random.swift */; };
 		C40E63BCEAC9F7790D9509DCC1C199BC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		C41FE92746D003CE80EC182751D3BAA7 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB5D9C589FEB3A6153A08E709B67CA /* PCBC.swift */; };
+		C41DDBE4ED265D3D12E9F8D45C0B703F /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2373C8FF0CD32ABC12A0693F6E700 /* Box.swift */; };
+		C46D111322C86D1836922FF5705D2628 /* RLPEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982632EC9D55A6B9EB539218DA465EBF /* RLPEncoder.swift */; };
+		C47688C1C0FE3F109715B7337DD220C0 /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B64B65AE129A10129290B89F22175A0 /* PromiseKit-dummy.m */; };
 		C54917971101FAC9B6D8B5DCC84A5765 /* OIDError.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D3D1509A26DA95233CDED9B89552F99 /* OIDError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C5FFA6A04591E99DA67B37FB65F71CFC /* secp256k1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A90896AC737FBBF78E7AF0E33EE26E54 /* secp256k1.framework */; };
-		C7785CF346C358A316953E4B11DB9939 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2922FA7AB33ABFC439CA8DF0158798 /* PKCS5.swift */; };
+		C6A142AF33F41E57DC768FC7D0845833 /* RPCRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143A30748D182578831D8985F9A39664 /* RPCRequest.swift */; };
+		C783EC1B67B931C69DA62D720B891430 /* TransactionWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECCD6D43C22282D8305CF3B3EA4AA05 /* TransactionWatcher.swift */; };
 		C88AC084D58886CFA6B666B49A5F87B6 /* BigInt-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D3BF37B8B3BEF16BA70DD4793361D39C /* BigInt-dummy.m */; };
-		C93D8A44C095377BEB032D2E034B43CF /* SolidityFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A37D8EC2C776EFD071F386425CFF195 /* SolidityFunction.swift */; };
-		C9FA6933511EFE345240197DB12E724B /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D247FDBD818DAE92F9A4FA69B04ACED5 /* PromiseKit.framework */; };
-		CA202C7EA91003EBB166126274E5650E /* secp256k1.swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4536060FFA06CD18532B76FF51EC1C /* secp256k1.swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CA25403FBCCFBD0351D1F709104DB9AA /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29ADCB525D3E9BA320C0F3DDE0A38F4 /* Checksum.swift */; };
-		CAE12CA401E600ED019E392FA28D621B /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = F84090BFF59F356C2BF0CFB5CBA4B393 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C917FA2EB6A047E2C2A2C2641CC910A1 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E312130B41D73E89A99467B044140F3C /* StreamEncryptor.swift */; };
+		CA4D9E0738986B77E48FF188E64BD0CA /* EthereumContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D546EE78D9FF588A77CFE8F1467B371 /* EthereumContract.swift */; };
 		CB50E970EBCEF35611DCC72D4FF5BF9F /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F53AC52FC65F357FF4B2230143B3C0 /* GCD.swift */; };
+		CB513027F2D8A878EAC880AC53345B69 /* String+HexBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDA254C0D200D9E98DDA0D36B320308 /* String+HexBytes.swift */; };
 		CB9023DDD28B4956DB365D7604CB706E /* OIDURLQueryComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 80641C11EDD0DBD1CDDB73876CF6E5C3 /* OIDURLQueryComponent.m */; };
-		CC25E300D14D60D9D058270F53ACB898 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56000A67F11F36A34BFB44BA71DFEAE /* Array+Foundation.swift */; };
 		CC7687F975157B67A426B389B896DDCD /* Exponentiation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A4D02D1CD7F1A1D926C535D7D7FE93 /* Exponentiation.swift */; };
-		CCC125F0B80A068A4554F97C6CF0D6ED /* Promisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9B8277C9B51995A03812B5035B00A6 /* Promisable.swift */; };
-		CCF7D73E1FC3728438D376F5902EF37C /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237A42E4E4ED1BFF2BD2776F4FD61B5B /* BlockDecryptor.swift */; };
 		CD0C6D4C7AA32CFB551514EEE8880BB9 /* BigInt.swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BFCC6E9A89BB3557D4882A3339BF612 /* BigInt.swift-dummy.m */; };
-		CDB0791EABB35F3379C7F4278CCE63C5 /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C18A3011506520BD091D6AEA254E917 /* ecmult_const_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CDDFF974FE17B5627C5320E6C790FA59 /* Promisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9B8277C9B51995A03812B5035B00A6 /* Promisable.swift */; };
+		CE128BAD80F1CC2E4C87B919A965F293 /* EthereumPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515D266F506E3B808CC2B9113C333FA8 /* EthereumPrivateKey.swift */; };
 		CE33F26C66D4C456D9C2E10B2D582F2E /* OIDAuthorizationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 533834F563267CE8E4BC4A32FDDBC120 /* OIDAuthorizationRequest.m */; };
-		CE7055110B85971C57FD75E628D53FF2 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F34294F989C963BDD2DCCD22F1A86BE /* NoPadding.swift */; };
-		CE910163B1EAF197A5377549BA061048 /* ABIConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75BD93C43CAE38E2D1C15252D25020 /* ABIConvertible.swift */; };
 		CF30E89F9D8701568EDC63BC42ACC067 /* OIDExternalUserAgentSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FFEA837FCE8DF51D0A9D481EFA6A310 /* OIDExternalUserAgentSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0257684613A5D2D297C3602D2AC1FBD /* Bitski.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC8C5779A0CB7ADF3BFA8D36BDED061 /* Bitski.swift */; };
+		D03119B1DB45FF25FCD560B5C77ABBF6 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB1B28906E3D399C3F613061BC69621 /* ChaCha20+Foundation.swift */; };
 		D08C645DE5798D5D92BF0614565E3876 /* Floating Point Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AEC25A50DF6B2754A247161F51D0D7 /* Floating Point Conversion.swift */; };
-		D0F9DEF82F6FC06DB976FAEEFA88C621 /* lax_der_parsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 21F11BBF550D7AC9B8B673093C7B2633 /* lax_der_parsing.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D12E4D75404304828939FA1F53D17934 /* Web3HttpProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4505F79FDF6D00830D21BA8B4EBE9D /* Web3HttpProvider.swift */; };
-		D325C22C0C28C48022BB5722D570B448 /* EthereumSyncStatusObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03EFCD69DF7C93BDF9E24A14B66FE0C /* EthereumSyncStatusObject.swift */; };
+		D15E441F139F010319E06BC13F6B66B5 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40F3984B105E8CF88E9803A08A1197A /* Bit.swift */; };
 		D32825837D747C83BC91F6E4A522D95C /* OIDRegistrationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC2ACD9747CC7B701A439F655DE94B8 /* OIDRegistrationRequest.m */; };
-		D46A4BEEB36AAA919CE7B905C00494AA /* String+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8FE4BB3617E0975EAFB4FF5A38474F /* String+Conversion.swift */; };
+		D441BAEB0678008C43F87610309A639B /* SolidityTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F67EF55D3D0C8048D4D0968662371A /* SolidityTuple.swift */; };
+		D466ECE4366754BCE09506186CD48838 /* field_10x26_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C14499F89076C2F2D82E055C4B4CB1B2 /* field_10x26_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D48C7DA0E6ABE9E22822D44224FAECDA /* Subtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB1086A33013F7391C4D6856DB6050F /* Subtraction.swift */; };
-		D4FB75F99F1759228540A9D741060C79 /* Bytes+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6503492B80CDB4B92129558A2D45A4 /* Bytes+UInt.swift */; };
-		D54956504E7C594600DD77FF944A9536 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		D55A05DF3E4042AE3F082F7558F674D8 /* num_gmp_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B456F53FA02293DC9D236966D30B84D /* num_gmp_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D56DDE3437A8AE99133F3546CF120056 /* ContractPromiseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580C3523D8A539AD350BC5B670F9F7A1 /* ContractPromiseExtensions.swift */; };
-		D57C7CC3F13760DA511AEB6FE0834655 /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536525D7183A9515ADA1A18C70B56E48 /* Rabbit.swift */; };
-		D5AB621379C2F3195AFC55869B2DE24E /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A278C159C12C8C0950797CEFC1C47FA /* CryptoSwift-dummy.m */; };
-		D71E0241C5994C85910E7585D56BA58B /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D75E984EE791E69A19C81A90B9765EC1 /* main_impl.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D7540C2B86331D7DA6B4B25439F1772F /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4202E42DE40D5719E2E981781DE17FEA /* Generics.swift */; };
+		D4C3BB1E2DABE79A31E6C65EB289575A /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F34294F989C963BDD2DCCD22F1A86BE /* NoPadding.swift */; };
+		D6C3A43A470A89672CF1407C65A7F9E3 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = ED072A9D839B5B3F5F492800B2EA899C /* scalar_4x64_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D75F57B7979CD766F2671027083BB7B3 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 9196E0C8FEC57535701FD288D0D36DE4 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D7B186F48D0FAACE37B1CE5D14AAEED6 /* EthereumLogObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7806C692718913987C6C548E3E9AF7D3 /* EthereumLogObject.swift */; };
 		D7BC11A992841B33082645731FA82F00 /* Bitwise Ops.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032464B68E3787EBA0128534D3396DBA /* Bitwise Ops.swift */; };
-		D7BFD9E87EBF8EBC4A8C6D4453D7AA38 /* num_gmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B029357F44677068E3781CBAA68538E /* num_gmp.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D80B42C3889AE086130A095C8985C83F /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAC0799A54D45463DB2E5809AC2E20A /* CBC.swift */; };
-		D9180D38BC36819DEF080D39605829B7 /* Web3+HTTPInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7464D2036BC40A05A648D966E88AD2E /* Web3+HTTPInitializer.swift */; };
-		D9F9638E93F2467B6DCED9487B79F60B /* Bitski-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2423262B7C0F6B3E9B81F8C755EC3095 /* Bitski-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D87531BFE26FADE1AF339E38EF9EA0B0 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA6C0362282DCBD4867F0BB6470DA92 /* Padding.swift */; };
+		DA2C0C8E4E972FAEC2350A905A17F6CD /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7CE9C050BCE85D5B562ACB693EA859 /* Guarantee.swift */; };
 		DA51823C8CFA70F6E78595AD7D005F84 /* OIDScopeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = BD04ED9BF5CA56FA93B3F57B1876357F /* OIDScopeUtilities.m */; };
-		DAA9CEDCABCDF99E0866DF2B9049D1D9 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1032C59DDA0DCF05A174B64DB4F74800 /* AES+Foundation.swift */; };
 		DAAA2FA40195C3A94E14DA753E69E4ED /* OIDAuthorizationFlowSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E453F2E91A0DE748741384029DDD87 /* OIDAuthorizationFlowSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAF46CD6BCC6A873F43F310B0777F27C /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2373C8FF0CD32ABC12A0693F6E700 /* Box.swift */; };
-		DB9D48CB7F49B90E9E5BB7DD8D45220D /* basic-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 98AB9E3F6B154E054173EF618F29F9F5 /* basic-config.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DEEB190E9FF6B65119C7DAB8786D6DFA /* UnsignedInteger+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2805C97988104C37686896937EED0EF9 /* UnsignedInteger+BytesConvertible.swift */; };
-		DEFCB948D5D33C78BC5DEED8333F88E4 /* secp256k1.swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5DDE3674312C83917BBD7C22D3F744 /* secp256k1.swift-dummy.m */; };
-		DF93B61D4196512DAD766D3CD99E3191 /* String+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E08499BC2D10EC549991CAA63E5941CB /* String+BytesConvertible.swift */; };
+		DB9DAFFD08093BF656754C466E85F14D /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = FE95557F57556015F007394DC4D24333 /* secp256k1_ecdh.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBA9A7279312E3BE94EC06C818C2B3D4 /* Eth+ABI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB24BE851A27D7D16E038AFE9FBDD539 /* Eth+ABI.swift */; };
+		DC0444ABBBC0555C248A0EC65A4A84B2 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4953586D8E95AE42DE002C5E6CBF90B /* BigInt.framework */; };
+		DC3C3320981A67BDDEC4A88C06B5FBB3 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1032C59DDA0DCF05A174B64DB4F74800 /* AES+Foundation.swift */; };
 		DFDBF03B2E6306446E38308BFE4331D3 /* Subtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F4ED3D815E39DC8AD1A5C5C574322E /* Subtraction.swift */; };
-		E090C4E91BEF26A890496410FDFF54D0 /* field_10x26.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0D58EC06A66A67DC90E8BCED8A955D /* field_10x26.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E005A989B07347CD50548EB5EC529BA3 /* ecmult_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = B55E1047B4ADC508F4478DBEFB5150FA /* ecmult_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E0CA3D027401DE70B9C07CB20A3FEBCA /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4048565B253349FFBD962C1BCC5A70A1 /* Codable.swift */; };
 		E0D543A2825B5E80CC740952C8DC3896 /* OIDExternalUserAgentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D84F37818EF7127B1A91BCB2B2E1029 /* OIDExternalUserAgentRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E12B0DF3B93803ECE3DE1ECAE11A1F03 /* EthereumData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA3DD5E2FA9D3A93FAADDD08FE4FC9 /* EthereumData.swift */; };
-		E22D907116DC355979955A97E61AC1AB /* Web3-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1EE4646F089C6B16110296FB283255 /* Web3-dummy.m */; };
+		E0EF54997AF62999CD53364F40EADF14 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29ADCB525D3E9BA320C0F3DDE0A38F4 /* Checksum.swift */; };
+		E19BCA19773F1E62B8C72B2FAE0C6779 /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A305D5B44C5E329F4DCD01944F8DF2F /* ChaCha20.swift */; };
+		E2819FAB33DB1EF7DB68E2C5C495B360 /* Web3-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 10B5F40771370A90A662268D21518DED /* Web3-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2A8F044A1F10E6017C9AD0A40915DC4 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0E0E87CAD90DABCB6C48C362EA0EFB /* UInt32+Extension.swift */; };
+		E2BA621313767054F90255AF8369915E /* Bitski-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D1929C623393A147FF5715CB647860 /* Bitski-dummy.m */; };
 		E2DDA02098EA48EBEA7011294D1C8E8D /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47563F0367C20BD8C477472B9C38EE8 /* BigInt.swift */; };
-		E35E8D2E207FA651114F184BBD51FE90 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48BF1A9DB93582728A2B5CA4EEDDA4 /* SecureBytes.swift */; };
+		E2FB6F8368D1B999716EE5CEEF987C0D /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA8ABD25A3D37260D678C0998267DDA /* PKCS7.swift */; };
 		E3610C97C8D968D7B9EE5A227BB8D928 /* OIDAuthorizationResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = DC715B4CAAB96FCA3E5936CDDB08691A /* OIDAuthorizationResponse.m */; };
-		E43E258712FA3091473C7CF8141ECAC1 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E9A31E6EB577BB453B0F40215C9F951 /* AnyPromise.m */; };
-		E50FED97D5345AB3A1CEA7CFDEB802F5 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = F523D40B1E8F6A137D5536218CF7A81A /* hash_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E6914A359D777BEB6A9750760DD70ED3 /* OIDAuthorizationService.m in Sources */ = {isa = PBXBuildFile; fileRef = 00A8DC7EC8298CA0CC5067255FE32D6B /* OIDAuthorizationService.m */; };
 		E6AE4B9D9E3FC9C206B15D1D69EB5D95 /* Pods-Bitski_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E71C5EFB8F1B5000118BDB47BAC81F3 /* Pods-Bitski_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E71E7E3BC0D7A67B8D7E57C225B07162 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BB73690C3E709351EB81211A87B2FF /* AEAD.swift */; };
-		E8D8CAD5225EC0B600AB575C /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D8CAD4225EC0B600AB575C /* NetworkClient.swift */; };
-		E94DC06D7EFCA94CD044E0B1199380C8 /* Eth+ABI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB24BE851A27D7D16E038AFE9FBDD539 /* Eth+ABI.swift */; };
+		E6E6D6D6CE9709D1B10D5A7AF7037845 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0343D0A95F5B8D1560D9132D482C810 /* OFB.swift */; };
+		E73E6CE5C14D22AFE6321239AC5C586B /* ecmult.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B02F52F78E30C83E5D9E06C594E9E21 /* ecmult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E84EE33222AB23BE0035C62E /* TransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84EE33122AB23BE0035C62E /* TransactionSigner.swift */; };
+		E866F94C7F009FEA02901A777E191E8B /* main_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D19CBB2AD10A2BE64017C029DB5544F /* main_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E8866D0CAAD6C59E00326B60CDF21E78 /* ERC20.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D188A981B5F72A0CFA327C792343BA /* ERC20.swift */; };
+		E897D9B129A66DEFED741BBD81E8AB86 /* scalar_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = D52E3CA20C05D922E35438AF7785D3F7 /* scalar_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E9785FB1BBEC85269D6691FABF847E58 /* NSURLRequest+HTTPBodyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E6D51369FFEE65F5C72D9A21274CFDC /* NSURLRequest+HTTPBodyTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9832E991648225A46F9F0BC4435A649 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A420DDC638101436632EF0E04C8B2FBE /* HMAC.swift */; };
-		EADCE42DB8F7D6086F55D877B541FC97 /* Bitski-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 566E5F1AC46CD3AB18072FFE27D4D0B8 /* Bitski-dummy.m */; };
-		EBB67B869EBFDE1B96BB534837843DF2 /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B64B65AE129A10129290B89F22175A0 /* PromiseKit-dummy.m */; };
+		EA68A9282496E5087A52E66612FE35A3 /* Web3+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858045962765091627D71EC66D7528A3 /* Web3+PromiseKit.swift */; };
+		EB1B73051EAA7B5CFA989AF6D4097CD5 /* EthereumQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAECE911EB4E6835E21EF83B1AC4DC5 /* EthereumQuantity.swift */; };
+		EB4E7BAEA20C93F0B8E6C7015BBF3D82 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40CFE54BE974C7318640767F792BD76 /* PKCS7Padding.swift */; };
 		EBCA6C96876AD01A759F408D8FF8B40B /* AppAuth-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 174352016D28BF768E5A14E930C08E13 /* AppAuth-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EBE535946FCE1B10EEFA80088EE32020 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EA121AD0B151E6AF4B132A14EF6E70 /* PBKDF2.swift */; };
+		EBF44F39B37C77087D2B78CBECCF7CB3 /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5F27AC3488E3D4A3398B474B6001D1 /* NetworkClient.swift */; };
 		EC104E5FBD60D55861C7B2F6D27D0F16 /* OIDAuthStateErrorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 17354566F2D8D7EDF4E64398F82C0771 /* OIDAuthStateErrorDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC43D86815D5868E45DDC9CADFB3274F /* field_5x52_asm_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 30C79749C116CC9EE01C72B33FE931A2 /* field_5x52_asm_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EC9F1E4D065BE7E4B9B34960AB75775E /* OIDURLQueryComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D525975FCECFA3DECCBBF4FC6826449 /* OIDURLQueryComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECF67455E6305AAC3D477B5D730B427B /* EthereumValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79113BF9474EF2C0DA505AE267BA2493 /* EthereumValue.swift */; };
-		EDAA902F8367B04B7407F7E83E00ADF3 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085CA1CBD19A09BD05AE31E9051D2EB9 /* BatchedCollection.swift */; };
-		EF13576CEA14B326148FB475C057A5CA /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF135BC7454FCBBB83C9B7830920D47 /* DigestType.swift */; };
-		EF9EA719C32376DDA73FFFB353FD616F /* EthereumLogObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7806C692718913987C6C548E3E9AF7D3 /* EthereumLogObject.swift */; };
-		EFE8D215566AB1EBAE1E81F7F6F1C66C /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDD585F5A5B062C9D6CCE5C11749556 /* Authenticator.swift */; };
-		F22A7BA014B2E4DEA1F92A94815649D7 /* ABI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9453B5EA76BC1DE094895414344D650D /* ABI.swift */; };
+		EE35F66DCA11D7E8190A6C0562C1CB3D /* secp256k1.swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5DDE3674312C83917BBD7C22D3F744 /* secp256k1.swift-dummy.m */; };
+		EE84C33E2031620275AD611B0E330B2A /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93130B9E769D34BABDE1AAC868F983C /* Configuration.swift */; };
+		EFDDA3F4B6CAD91D45500B8D93DDABB6 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D8A660D827B2C759F8C6C3B747FDA3 /* HMAC+Foundation.swift */; };
+		F0435E64FC29BE74A2EA9FB9E98524EC /* ecmult_const_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C18A3011506520BD091D6AEA254E917 /* ecmult_const_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F2554B2C28F2843D2BDF68D9E8D6FDDC /* String+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E08499BC2D10EC549991CAA63E5941CB /* String+BytesConvertible.swift */; };
 		F4282A5F0060121CA7C6AF5F2CDCD1E7 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FE5AA949275BD757130D43CEF454A2E /* SafariServices.framework */; };
-		F4ABBE7BBFD2B42A96BD98F9E0AD2AD4 /* secp256k1_ecdh.h in Headers */ = {isa = PBXBuildFile; fileRef = FE95557F57556015F007394DC4D24333 /* secp256k1_ecdh.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4B9722E48EE4A1214F73B14144AEB14 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B14A1B038C564FA60D23A57A8A9E03C8 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4ED355C99770B31BA36020C1AC3AE4C /* OIDScopes.h in Headers */ = {isa = PBXBuildFile; fileRef = 230668EE633F35B8F74D16406AA71412 /* OIDScopes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F567EFF5EAE42C9819AD856BB8A0CB3E /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8015B6CBD7311CADC0A6C13003DEF4 /* Deprecations.swift */; };
-		F61ADFD2056937B365A976F5EEFAA58D /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556B923653E8429D5577DDBD6F0D5A6B /* MD5.swift */; };
-		F796F8367D1DA57157CA7F3AE7126C9E /* EthereumContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D546EE78D9FF588A77CFE8F1467B371 /* EthereumContract.swift */; };
-		F7A9120F5F51AA0C0D25191BDCBE5E79 /* scalar_4x64_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = ED072A9D839B5B3F5F492800B2EA899C /* scalar_4x64_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F5FDBF795EB9338AFD45CB6B0DA98344 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A420DDC638101436632EF0E04C8B2FBE /* HMAC.swift */; };
+		F69EEEEDA62BF458233C98A5162352B6 /* Bitski.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173CEA7A2979F36EFD73F65054B4B122 /* Bitski.swift */; };
+		F74AE36CA966937D65639FB7AAFC36A4 /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = BAB02E4D4C45C6163156D4A21D9B31DA /* scalar_4x64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F77FD61D0599DE8B5A4B69D5FC035088 /* EthereumValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79113BF9474EF2C0DA505AE267BA2493 /* EthereumValue.swift */; };
 		F815510D99CED8EE498CFF48D1FB8D4C /* OIDRegistrationResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = BD48C5A6CEA16E96AC2123FDE6F317A8 /* OIDRegistrationResponse.m */; };
+		F827001487F442205D4CCECD6EF92244 /* hash_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = F523D40B1E8F6A137D5536218CF7A81A /* hash_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F888177A305F3A17F04576DE7C9975CC /* Web3.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15389599F303AEC177A5CF1FC1E9D96 /* Web3.swift */; };
 		F89E03219467FB885E84086B8000B471 /* OHHTTPStubs-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2C9F117D611330E621D1FA403BCFA7 /* OHHTTPStubs-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8C201AFC8D11F33A8346E7F0CCC7CC4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
 		F95CAA42704C91E9A788981F33F0E4B3 /* OHHTTPStubs-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CF7D499D0F05CA22EC19B015973FE4A4 /* OHHTTPStubs-dummy.m */; };
-		FA72799CB912037882CE07C43B2554A3 /* scalar_4x64.h in Headers */ = {isa = PBXBuildFile; fileRef = BAB02E4D4C45C6163156D4A21D9B31DA /* scalar_4x64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F9E3FD3DD77271FEC3E5EE7D9BFF3E35 /* RandomHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB255B3DED4359AC89C3F0318CA21D /* RandomHex.swift */; };
+		FA4A4F2C65DB75001527199FBB755B3A /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3547644B575AC1B76010C9B58574A6FE /* Thenable.swift */; };
 		FA77409BB7778062C6BD5D5449E4FCB4 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1185BB08852C4D931066BF7E582B2E3 /* CFNetwork.framework */; };
-		FAA51A1081C22D64CED12C9C4EE03AD9 /* SolidityInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DCBBE4F4D5D555E4E14C39F93D6756 /* SolidityInvocation.swift */; };
-		FB11CD7BCB55ADDA06B2498D8299C907 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F995DDFC83C919B3418829E1E109F1AA /* Utils+Foundation.swift */; };
-		FB22BC377B6EEC4336DED94DA402BC82 /* Types+RLPItemConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D3FAD2A1C774E4D88E6140EBA8A714 /* Types+RLPItemConvertible.swift */; };
+		FB2F9312A88E5D9137C4C52028D281CC /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556B923653E8429D5577DDBD6F0D5A6B /* MD5.swift */; };
+		FB9D9CD334867D31C0365857A542C9FB /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = 73F27A18BC7FA00779D71DEBF1CE9212 /* field.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FBA1A3FE0F1A75EC61BC2CF8B06ACC1A /* group_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F289D79DE695B57E7C08BC9C746D0F /* group_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FBDEEF432C313BE1B9FCF019D9FEA473 /* Words and Bits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086DE1D67013D3F8E7C23934A7009C55 /* Words and Bits.swift */; };
-		FBF3588D2A4604AC0FEB90CB05BAE34A /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695FA613ADA67889EF9B4A2C355DE7F7 /* Rabbit+Foundation.swift */; };
+		FBE8E04E31C02459F3AD0BDE81A172CA /* Data+BytesConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A1B048611F8BED9099D09B7E1CBBEB /* Data+BytesConvertible.swift */; };
 		FC125ABEDF610EB4A143B3E1E3E511E0 /* SquareRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA43EBB9F67E8C7BA187B4F3E489F5B /* SquareRoot.swift */; };
-		FCDDEA7211C8BD7FB202C5CC2D7370A3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEB408F3C74339CD032E658126F78330 /* Foundation.framework */; };
-		FDBA79EA05A72D7BD247077B6E7D39E7 /* EthereumCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55186C72814D9D47C340E95D2F6FF55 /* EthereumCall.swift */; };
+		FDA3DA1DF18693963061C04EF43B8637 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5735A353C79AA4280DDCCA3684C5FA85 /* Poly1305.swift */; };
+		FDD99982B999A60D1B0EE3E8E76E3B6C /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 449C92465B7DF10B5B00991B70FF1CE8 /* AppAuth.framework */; };
+		FE6651104652572D4EF919CBD9C49DD7 /* secp256k1.swift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4536060FFA06CD18532B76FF51EC1C /* secp256k1.swift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FEB09606B26AF6EAF47160DC666E9AFE /* Strideable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12F7A540A56A5333251DAB6A9230E9E /* Strideable.swift */; };
-		FEBF6245A58FB1F6E3822164DD5855A3 /* scalar.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC023AB111D24FEEDBFA70A10D3D7D2 /* scalar.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEE99A34F17FD4FC04549FCB3FC8E2D7 /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05E4D71E45C370AE8930B16C3ED286C /* Comparable.swift */; };
-		FFEB503E96658225E552161A332C8115 /* field_5x52_int128_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = C6C10C4872E85827C103893A7B8EE8E8 /* field_5x52_int128_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF0E0AB757B09C9394D75D194A6FBF84 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C583BFDFCF9B743BFE3268CE492FDB6 /* Cryptors.swift */; };
+		FF3DA16D708B4E6328BC66626D041229 /* ecmult_gen.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D98C57FEAFA6B582B3176D8225EFD60 /* ecmult_gen.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFF1B2153862FBF3C5C5B2F886551ED8 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 239D97CB5AAE0F93697D9F61C7390D78 /* when.m */; };
 		FFFDFFEBD0886ABFF3CEBAF4A945626D /* Multiplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973F72E3F0CC74DC8A32060F7A3E0A65 /* Multiplication.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		025717E3E3759D9BA87948A9FB344F0A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 99313990C1D76A6D1D017868B6975CC8;
+			remoteInfo = CryptoSwift;
+		};
 		11240C592025CD323D40DFABD7307668 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -425,20 +434,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4FF1EE5493800BD023263DE462914B83;
 			remoteInfo = secp256k1.swift;
-		};
-		1F30164FFA5BF71FB96D0AFC85B96DDB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 99313990C1D76A6D1D017868B6975CC8;
-			remoteInfo = CryptoSwift;
-		};
-		2421D4433275BEAA005197250F366EE0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
-			remoteInfo = PromiseKit;
 		};
 		26A549132C7F979203C4D9076BB7F8E4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -475,7 +470,7 @@
 			remoteGlobalIDString = 09DD83B7D075842A3A5105AD410BD38A;
 			remoteInfo = BigInt;
 		};
-		3C7E21D451158F387896C82170856A8F /* PBXContainerItemProxy */ = {
+		3A5D36D30046036326C533AEBE09C5D1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -503,6 +498,27 @@
 			remoteGlobalIDString = 42672A41066C4682CBE265FBB44562B2;
 			remoteInfo = Bitski;
 		};
+		49FBC3916BC049091978DCFC0E439B6D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C642AA10FB29936669CC269F42079C6;
+			remoteInfo = AppAuth;
+		};
+		4C99ACDBD332990083F49B7FFD80FE1A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
+			remoteInfo = PromiseKit;
+		};
+		544E88793A461286340B8416B53761AF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
+			remoteInfo = PromiseKit;
+		};
 		5FC101D3BF6DF156AD9CC9D77DAAEA19 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -524,19 +540,12 @@
 			remoteGlobalIDString = 377DAE4050D766B30C3A484B8525BB35;
 			remoteInfo = SipHash;
 		};
-		7B21DAEFFD83164E40570D6AC6F6BF70 /* PBXContainerItemProxy */ = {
+		7740E4631A7C7B8743A601AAB37273F3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7C579CE66A1E7A9AA33CA5F97F9C22C5;
-			remoteInfo = PromiseKit;
-		};
-		7C31D603D7421DCA3D3B79643B5EB3BF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C8CD155B863C8C242EE4BFB54258F488;
-			remoteInfo = BigInt.swift;
+			remoteGlobalIDString = CC9BC1645C866B2D07A22D0A3EBF42CA;
+			remoteInfo = Web3;
 		};
 		803B9169474978CC306ACB032BDE4B9C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -545,12 +554,26 @@
 			remoteGlobalIDString = 09DD83B7D075842A3A5105AD410BD38A;
 			remoteInfo = BigInt;
 		};
+		8207C78E69E7F6D8D99A6ED320AEB8DB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4FF1EE5493800BD023263DE462914B83;
+			remoteInfo = secp256k1.swift;
+		};
 		906B69A25DC901A2E16CD1D7B745C087 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 377DAE4050D766B30C3A484B8525BB35;
 			remoteInfo = SipHash;
+		};
+		9445698EBCF4B893980DDD15DDCEA2FD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C8CD155B863C8C242EE4BFB54258F488;
+			remoteInfo = BigInt.swift;
 		};
 		95FF158D7AC8D3A4364402AEFC5ED1CC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -566,13 +589,6 @@
 			remoteGlobalIDString = 42672A41066C4682CBE265FBB44562B2;
 			remoteInfo = Bitski;
 		};
-		BB4BA5006C23A591F50F2DA903A72027 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4FF1EE5493800BD023263DE462914B83;
-			remoteInfo = secp256k1.swift;
-		};
 		CBC2C07C6028285EA529E63673CD2209 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -580,7 +596,7 @@
 			remoteGlobalIDString = C8CD155B863C8C242EE4BFB54258F488;
 			remoteInfo = BigInt.swift;
 		};
-		F13E3F99762A2871B76B2185CDB8312D /* PBXContainerItemProxy */ = {
+		EF3D552DA3105C68B77B8B639333AAE1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -594,23 +610,10 @@
 			remoteGlobalIDString = 377DAE4050D766B30C3A484B8525BB35;
 			remoteInfo = SipHash;
 		};
-		F51E15EDCA95669BF7F50FD8D90C6A6F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CC9BC1645C866B2D07A22D0A3EBF42CA;
-			remoteInfo = Web3;
-		};
-		F77C51DA60384F0063551DC39BB0EA1C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5C642AA10FB29936669CC269F42079C6;
-			remoteInfo = AppAuth;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00A68AC75C5F0B201721E72FE27EFD6B /* Bitski.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Bitski.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski.html; sourceTree = "<group>"; };
 		00A8DC7EC8298CA0CC5067255FE32D6B /* OIDAuthorizationService.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDAuthorizationService.m; path = Source/OIDAuthorizationService.m; sourceTree = "<group>"; };
 		00BB73690C3E709351EB81211A87B2FF /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
 		012B9AE4D5BE0AA1CF8A0D1F59A7E992 /* OIDGrantTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDGrantTypes.h; path = Source/OIDGrantTypes.h; sourceTree = "<group>"; };
@@ -623,17 +626,17 @@
 		05EA121AD0B151E6AF4B132A14EF6E70 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
 		063393ACE9B5BF415EE22C147653A250 /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
 		06CD449BF26AA21F102E5485934CBD30 /* UInt+BytesRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt+BytesRepresentable.swift"; path = "Web3/Classes/Core/Toolbox/UInt+BytesRepresentable.swift"; sourceTree = "<group>"; };
-		079ADA80BD6CBB7069C8FA6E9FACFF1A /* Authentication.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Authentication.html; path = docs/Authentication.html; sourceTree = "<group>"; };
 		07A1BD69C6391FF8C768F1D64EC93068 /* BigInt.swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = BigInt.swift.modulemap; sourceTree = "<group>"; };
 		085CA1CBD19A09BD05AE31E9051D2EB9 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
 		086DE1D67013D3F8E7C23934A7009C55 /* Words and Bits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Words and Bits.swift"; path = "sources/Words and Bits.swift"; sourceTree = "<group>"; };
 		0896037BAFFF5EE1756D8C7A8D7E4C64 /* Exports+PromiseKit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Exports+PromiseKit.swift"; path = "Web3/Classes/PromiseKit/Exports+PromiseKit.swift"; sourceTree = "<group>"; };
 		09D3CC390520CB87BB7A790CA56CD906 /* Pods-Bitski_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Bitski_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		0A6D766B5B9AC66E08AAC62F16621BCF /* scalar_8x32_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32_impl.h; path = secp256k1/Classes/secp256k1/src/scalar_8x32_impl.h; sourceTree = "<group>"; };
-		0B16EB8BB0C57E386A2D125EBD0E6F7F /* BitskiHTTPProvider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = BitskiHTTPProvider.html; path = docs/Classes/BitskiHTTPProvider.html; sourceTree = "<group>"; };
 		0C13CE6B614EADAC62DFFF17103C1279 /* OIDAuthorizationService.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDAuthorizationService.h; path = Source/OIDAuthorizationService.h; sourceTree = "<group>"; };
 		0CFBD239002482DC9823DA4FB1CFB46C /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
 		0D5537CAE630753585F4EAF3239F98C6 /* Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Random.swift; path = BigInt/Classes/Random.swift; sourceTree = "<group>"; };
+		0D7D51E8B7A94869F72EA30E5325E714 /* BitskiHTTPProvider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = BitskiHTTPProvider.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/BitskiHTTPProvider.html; sourceTree = "<group>"; };
+		0DAE6ADBDD8AF654B9FD88CDD26CB2AA /* Bitski-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Bitski-Info.plist"; sourceTree = "<group>"; };
 		0EE583903970FCA83ABB6B9437406F42 /* BigInt-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-umbrella.h"; sourceTree = "<group>"; };
 		0FB1B28906E3D399C3F613061BC69621 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
 		1032C59DDA0DCF05A174B64DB4F74800 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
@@ -641,17 +644,18 @@
 		10F82FE1342A785F37DCAE85F85BD013 /* eckey_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey_impl.h; path = secp256k1/Classes/secp256k1/src/eckey_impl.h; sourceTree = "<group>"; };
 		11548A2A342540A4BB1A8C7356E1C3C7 /* Pods-Bitski_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Bitski_Tests-umbrella.h"; sourceTree = "<group>"; };
 		11A29795010F71C28E39A47DC25AAF06 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		11C71BA6287289ACD68A21282B11A442 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = index.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/index.html; sourceTree = "<group>"; };
 		11FA9656BA03C8A4519651ADB30C0BB3 /* OIDAuthState+IOS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OIDAuthState+IOS.h"; path = "Source/iOS/OIDAuthState+IOS.h"; sourceTree = "<group>"; };
-		13E177C129856D31D78ECB069BE8DA90 /* spinner.gif */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.gif; name = spinner.gif; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/spinner.gif; sourceTree = "<group>"; };
+		121A18E3926800928494A24DCE9CA540 /* Bitski.tgz */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = Bitski.tgz; path = docs/docsets/Bitski.tgz; sourceTree = "<group>"; };
 		143A30748D182578831D8985F9A39664 /* RPCRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RPCRequest.swift; path = Web3/Classes/Core/Json/RPCRequest.swift; sourceTree = "<group>"; };
-		1511A9EA6E89B004756466D72804C49B /* Status.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Status.html; path = docs/Classes/TransactionWatcher/Status.html; sourceTree = "<group>"; };
+		150DA45616AFAB75349DAD331B95A9E5 /* BitskiTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiTransaction.swift; sourceTree = "<group>"; };
+		152B25AF0B1430635B283B66150D3368 /* Bitski-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Bitski-prefix.pch"; sourceTree = "<group>"; };
 		16F67EF55D3D0C8048D4D0968662371A /* SolidityTuple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SolidityTuple.swift; path = Web3/Classes/ContractABI/ABI/SolidityTuple.swift; sourceTree = "<group>"; };
 		170A246FFFEB5091652A59BFC748FB78 /* BigUInt+BytesConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BigUInt+BytesConvertible.swift"; path = "Web3/Classes/Core/Toolbox/BigUInt+BytesConvertible.swift"; sourceTree = "<group>"; };
+		170E536A0B49B94A36324F6FA9A10913 /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
 		17354566F2D8D7EDF4E64398F82C0771 /* OIDAuthStateErrorDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDAuthStateErrorDelegate.h; path = Source/OIDAuthStateErrorDelegate.h; sourceTree = "<group>"; };
+		173CEA7A2979F36EFD73F65054B4B122 /* Bitski.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Bitski.swift; sourceTree = "<group>"; };
 		174352016D28BF768E5A14E930C08E13 /* AppAuth-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AppAuth-umbrella.h"; sourceTree = "<group>"; };
 		1761BE4AA4879151707A4EC0B13527CE /* Pods-Bitski_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Bitski_Tests-dummy.m"; sourceTree = "<group>"; };
-		182F5F87BF189045F912FD2127C25A0B /* Bitski.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Bitski.modulemap; sourceTree = "<group>"; };
 		18CE3BC3DD777C3A6E537B164356B371 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
 		18EC10FF6294C038EFAA98FEDEF0F4A0 /* RLPItemConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLPItemConvertible.swift; path = Web3/Classes/Core/RLP/RLPItemConvertible.swift; sourceTree = "<group>"; };
 		19C643F25902474911AA846B5F0649D8 /* Int+ETH.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+ETH.swift"; path = "Web3/Classes/Core/Toolbox/Int+ETH.swift"; sourceTree = "<group>"; };
@@ -665,7 +669,6 @@
 		1ECA1CA409953AC336127995169C7DE3 /* lax_der_privatekey_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lax_der_privatekey_parsing.c; path = secp256k1/Classes/secp256k1/contrib/lax_der_privatekey_parsing.c; sourceTree = "<group>"; };
 		1F34294F989C963BDD2DCCD22F1A86BE /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
 		1F6F3F4927693CE47220FE7288267569 /* OIDTokenUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDTokenUtilities.m; path = Source/OIDTokenUtilities.m; sourceTree = "<group>"; };
-		1F738B1647E52516DEFACB833D0F3C4E /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		1FD686313CD800170FA82E8A9DD679FC /* ERC165.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ERC165.swift; path = Web3/Classes/ContractABI/Contract/ERC165.swift; sourceTree = "<group>"; };
 		207EFF6805B6AA69AF0F173DEEFCE081 /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
 		218C6513B3261248A499DE5FD6F74BB2 /* Bytes+TrimLeadingZeros.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bytes+TrimLeadingZeros.swift"; path = "Web3/Classes/Core/Toolbox/Bytes+TrimLeadingZeros.swift"; sourceTree = "<group>"; };
@@ -677,7 +680,7 @@
 		2365204D135DC8A8E2A1F72951731D1D /* OIDErrorUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDErrorUtilities.m; path = Source/OIDErrorUtilities.m; sourceTree = "<group>"; };
 		237A42E4E4ED1BFF2BD2776F4FD61B5B /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
 		239D97CB5AAE0F93697D9F61C7390D78 /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
-		2423262B7C0F6B3E9B81F8C755EC3095 /* Bitski-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Bitski-umbrella.h"; sourceTree = "<group>"; };
+		23EB255B3DED4359AC89C3F0318CA21D /* RandomHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RandomHex.swift; sourceTree = "<group>"; };
 		24416977C48E4B00F915DE215FC5B3A6 /* OIDServiceConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDServiceConfiguration.m; path = Source/OIDServiceConfiguration.m; sourceTree = "<group>"; };
 		252187DD77BC56265590534906CF2F0F /* Pods-Bitski_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Bitski_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		2523008AF6A9A8346E0334C84E7CB005 /* Addition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Addition.swift; path = BigInt/Classes/Addition.swift; sourceTree = "<group>"; };
@@ -687,29 +690,29 @@
 		2805C97988104C37686896937EED0EF9 /* UnsignedInteger+BytesConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UnsignedInteger+BytesConvertible.swift"; path = "Web3/Classes/Core/Toolbox/UnsignedInteger+BytesConvertible.swift"; sourceTree = "<group>"; };
 		288BECCA915ADBE5BF22DB25E1F60D69 /* ecmult_const.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const.h; path = secp256k1/Classes/secp256k1/src/ecmult_const.h; sourceTree = "<group>"; };
 		295136276F90DC4E52755DAAB0C4D24C /* RLPDecoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLPDecoder.swift; path = Web3/Classes/Core/RLP/RLPDecoder.swift; sourceTree = "<group>"; };
-		29AEBF6AAF305B560ED18A13064706C4 /* typeahead.jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = typeahead.jquery.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/typeahead.jquery.js; sourceTree = "<group>"; };
 		2A4CFD6275662ABEB5EE36C294962736 /* group.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group.h; path = secp256k1/Classes/secp256k1/src/group.h; sourceTree = "<group>"; };
 		2B46C190181071331582E79DE8615F82 /* OHHTTPStubs.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = OHHTTPStubs.xcconfig; sourceTree = "<group>"; };
-		2C3CD13AD9D05719217B0BBB2CDBECBE /* TransactionWatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionWatcher.swift; sourceTree = "<group>"; };
+		2C7A1B44B51D8F93BBFE230BF8B839A0 /* TransactionWatcherDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = TransactionWatcherDelegate.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Protocols/TransactionWatcherDelegate.html; sourceTree = "<group>"; };
+		2C8CBC8F97EEA3F18027476DCB138F40 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jazzy.js; sourceTree = "<group>"; };
 		2D19CBB2AD10A2BE64017C029DB5544F /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1/Classes/secp256k1/src/modules/recovery/main_impl.h; sourceTree = "<group>"; };
 		2D3D1509A26DA95233CDED9B89552F99 /* OIDError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDError.h; path = Source/OIDError.h; sourceTree = "<group>"; };
 		2D48BF1A9DB93582728A2B5CA4EEDDA4 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
-		2DC0531FBD04AD0A2480D936FCC552F6 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = jazzy.css; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/css/jazzy.css; sourceTree = "<group>"; };
+		2D5167871B953490C3D6C18399B468FC /* AuthenticationError.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = AuthenticationError.html; path = docs/Classes/Bitski/AuthenticationError.html; sourceTree = "<group>"; };
 		2DDA3DD5E2FA9D3A93FAADDD08FE4FC9 /* EthereumData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumData.swift; path = Web3/Classes/Core/Json/EthereumData.swift; sourceTree = "<group>"; };
 		2DF2971B3B9A50014F7F2897CC463876 /* OHHTTPStubsResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsResponse.h; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.h; sourceTree = "<group>"; };
 		2E59F24962E2699191425BB638B69406 /* Comparable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Comparable.swift; path = sources/Comparable.swift; sourceTree = "<group>"; };
-		2E85FF807AFE47AF75551DE19C3F2C1D /* Utilities.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Utilities.html; path = docs/Utilities.html; sourceTree = "<group>"; };
 		2EAC0799A54D45463DB2E5809AC2E20A /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
+		2EC9662E0BF5E5694814040F4B98BB7E /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
 		2F6440CCAC2E249321FB1DA7E6EA6E30 /* Compatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Compatibility.h; path = OHHTTPStubs/Sources/Compatibility.h; sourceTree = "<group>"; };
+		2F6BF26B7D7741674D91B7B94EED1983 /* BitskiProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiProvider.swift; sourceTree = "<group>"; };
 		2F8015B6CBD7311CADC0A6C13003DEF4 /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Deprecations.swift; sourceTree = "<group>"; };
-		2FA343DF75D24889AC82EF01C5B12DE7 /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
+		3011013EEE54F21D56669D84C8F2FB69 /* jazzy.search.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.search.js; path = docs/js/jazzy.search.js; sourceTree = "<group>"; };
 		30C79749C116CC9EE01C72B33FE931A2 /* field_5x52_asm_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_asm_impl.h; path = secp256k1/Classes/secp256k1/src/field_5x52_asm_impl.h; sourceTree = "<group>"; };
 		3166E42191BD5D7B635D6D79D85EF8CB /* Integer Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Integer Conversion.swift"; path = "sources/Integer Conversion.swift"; sourceTree = "<group>"; };
 		31A3CDDDE118B18E8860347C535A3D36 /* OIDFieldMapping.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDFieldMapping.m; path = Source/OIDFieldMapping.m; sourceTree = "<group>"; };
 		31C4AFAA24951C57C70CE58986095557 /* scalar_8x32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_8x32.h; path = secp256k1/Classes/secp256k1/src/scalar_8x32.h; sourceTree = "<group>"; };
 		33170F7AFC5A8669262E70B9B724531A /* OHHTTPStubsMethodSwizzling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsMethodSwizzling.m; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.m; sourceTree = "<group>"; };
 		331F313EE32AB46BE05EEE033057F6E8 /* RPCResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RPCResponse.swift; path = Web3/Classes/Core/Json/RPCResponse.swift; sourceTree = "<group>"; };
-		333F102CADB69540C44DC4078EABE3B8 /* Bitski-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Bitski-Info.plist"; sourceTree = "<group>"; };
 		336C4CEBA01501692EBF7B59CEBA2EE1 /* field_5x52_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_impl.h; path = secp256k1/Classes/secp256k1/src/field_5x52_impl.h; sourceTree = "<group>"; };
 		341545CED74E916909AAE4161553ED92 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
 		34FABE3563F13AF3E852B143E5CB5B2B /* Values+GeneralHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Values+GeneralHashable.swift"; path = "Web3/Classes/Core/Toolbox/Values+GeneralHashable.swift"; sourceTree = "<group>"; };
@@ -720,7 +723,7 @@
 		39BA8AAD9FCA1E57010637DE1E93D814 /* OIDScopes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDScopes.m; path = Source/OIDScopes.m; sourceTree = "<group>"; };
 		3A74A4AC42DDE4E06563017906E62CBE /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
 		3B029357F44677068E3781CBAA68538E /* num_gmp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp.h; path = secp256k1/Classes/secp256k1/src/num_gmp.h; sourceTree = "<group>"; };
-		3CA5175BA7A9D1917B4A501F0462185A /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
+		3BA1262E30AB183459F1DFAE4EC8BB03 /* Web3 Provider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = "Web3 Provider.html"; path = "docs/docsets/Bitski.docset/Contents/Resources/Documents/Web3 Provider.html"; sourceTree = "<group>"; };
 		3DC2663D7B4D9C4B84E0DFCF14E85908 /* ABIObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIObject.swift; path = Web3/Classes/ContractABI/Contract/ABIObject.swift; sourceTree = "<group>"; };
 		3E6D51369FFEE65F5C72D9A21274CFDC /* NSURLRequest+HTTPBodyTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+HTTPBodyTesting.h"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.h"; sourceTree = "<group>"; };
 		3E9A31E6EB577BB453B0F40215C9F951 /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
@@ -730,37 +733,38 @@
 		4048565B253349FFBD962C1BCC5A70A1 /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = BigInt/Classes/Codable.swift; sourceTree = "<group>"; };
 		406ADD96DAF8931C73674189BFF4D0EC /* Pods-Bitski_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Bitski_Example-dummy.m"; sourceTree = "<group>"; };
 		40F55D4FFC2E7B05F9DEBEA3243A6A99 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
-		40F569C16A53C9EE37B5066CE53DC86D /* jazzy.search.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.search.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jazzy.search.js; sourceTree = "<group>"; };
 		4118E75EBC813C8B82BCAFD6E7C76E8D /* Web3-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Web3-prefix.pch"; sourceTree = "<group>"; };
 		417DF7829B63B58F6372326ECA72984E /* PrimeTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimeTest.swift; path = BigInt/Classes/PrimeTest.swift; sourceTree = "<group>"; };
 		41A1090B90FB7A5CF6399B5C7434533F /* OHPathHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHPathHelpers.h; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.h; sourceTree = "<group>"; };
 		4202E42DE40D5719E2E981781DE17FEA /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
+		423569E307C93EECDB2618D13D01783F /* BitskiAuthorizationAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiAuthorizationAgent.swift; sourceTree = "<group>"; };
+		434FCEC94C6AF5F8CB999187F0427C80 /* AuthenticationError.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = AuthenticationError.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski/AuthenticationError.html; sourceTree = "<group>"; };
 		449BB9070AC5DEE06845E24187A9DC4A /* OIDExternalUserAgentIOS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentIOS.h; path = Source/iOS/OIDExternalUserAgentIOS.h; sourceTree = "<group>"; };
 		449C92465B7DF10B5B00991B70FF1CE8 /* AppAuth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppAuth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		450785CEA22D7782887AAAA5B52F1154 /* secp256k1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = secp256k1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		457A9270EBCDBA7939F85BCA57790ACE /* Web3 Provider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = "Web3 Provider.html"; path = "docs/docsets/Bitski.docset/Contents/Resources/Documents/Web3 Provider.html"; sourceTree = "<group>"; };
 		45DF1AC965E53A1A13762320B26C7435 /* ABIEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIEncoder.swift; path = Web3/Classes/ContractABI/ABI/ABIEncoder.swift; sourceTree = "<group>"; };
 		46BA7032214B113B97F2679A3A14F21D /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
-		488C317C55895E8A84B5E5F68D9AB1F2 /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jquery.min.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jquery.min.js; sourceTree = "<group>"; };
 		4A278C159C12C8C0950797CEFC1C47FA /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
-		4B02D530DFE0FD7924387B16EA5A70D9 /* BitskiTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiTransaction.swift; sourceTree = "<group>"; };
-		4B1C43A2E7C34457F5EA43662366DB4C /* typeahead.jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = typeahead.jquery.js; path = docs/js/typeahead.jquery.js; sourceTree = "<group>"; };
 		4B328DA7623921051280C891F93ACC20 /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = sources/Codable.swift; sourceTree = "<group>"; };
 		4B8FE4BB3617E0975EAFB4FF5A38474F /* String+Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Conversion.swift"; path = "Web3/Classes/Core/Toolbox/String+Conversion.swift"; sourceTree = "<group>"; };
 		4C773F84EEA68D065561E327512D5E07 /* Hashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Hashable.swift; path = sources/Hashable.swift; sourceTree = "<group>"; };
 		4CA3AFA7A34EA7C402817807A481AE93 /* secp256k1_recovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_recovery.h; path = secp256k1/Classes/secp256k1/include/secp256k1_recovery.h; sourceTree = "<group>"; };
 		4CCBD7B091889D8FF310AE9D75AB73FE /* Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Random.swift; path = sources/Random.swift; sourceTree = "<group>"; };
-		4CD43583EC09CD160903F218919513AC /* Watching Transactions.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = "Watching Transactions.html"; path = "docs/Watching Transactions.html"; sourceTree = "<group>"; };
 		4D546EE78D9FF588A77CFE8F1467B371 /* EthereumContract.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumContract.swift; path = Web3/Classes/ContractABI/Contract/EthereumContract.swift; sourceTree = "<group>"; };
 		4E71C5EFB8F1B5000118BDB47BAC81F3 /* Pods-Bitski_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Bitski_Example-umbrella.h"; sourceTree = "<group>"; };
-		4E86D78516A045EAFC3E274B12385AB8 /* AuthenticationError.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = AuthenticationError.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski/AuthenticationError.html; sourceTree = "<group>"; };
 		4E9B8277C9B51995A03812B5035B00A6 /* Promisable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promisable.swift; path = Web3/Classes/PromiseKit/Promisable.swift; sourceTree = "<group>"; };
+		4EAF529C4E100BA6C72944600B7A89C9 /* typeahead.jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = typeahead.jquery.js; path = docs/js/typeahead.jquery.js; sourceTree = "<group>"; };
 		4EE434EC2423F52615425687624FA0C6 /* secp256k1.swift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = secp256k1.swift.modulemap; sourceTree = "<group>"; };
+		4F05DAFFC8B03D69EE01CD873FFFB753 /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
+		4F4093EFE5C5A9A89D62CFD333432FD0 /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/carat.png; sourceTree = "<group>"; };
 		50C9EDBA8B04A7D69FEA3B57D75C29C4 /* EthereumTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumTransaction.swift; path = Web3/Classes/Core/Transaction/EthereumTransaction.swift; sourceTree = "<group>"; };
-		50E910011B4EA7272F7A9BFD5193BAF3 /* Bitski-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Bitski-prefix.pch"; sourceTree = "<group>"; };
 		515D266F506E3B808CC2B9113C333FA8 /* EthereumPrivateKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumPrivateKey.swift; path = Web3/Classes/Core/Transaction/EthereumPrivateKey.swift; sourceTree = "<group>"; };
+		52C06D2D25F2F9536401D2F2003B6F42 /* Web3 Provider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = "Web3 Provider.html"; path = "docs/Web3 Provider.html"; sourceTree = "<group>"; };
 		52D85D86975A923B27BAF210B195A12E /* ABIDecoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIDecoder.swift; path = Web3/Classes/ContractABI/ABI/ABIDecoder.swift; sourceTree = "<group>"; };
+		52FA2E16934FD0B56CDEE8BD59B99F4B /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
 		5316F6915675EB5CE9BE363FFF9C17BD /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
+		531C4961F01E1F62EEA5D4C0B1B49A5D /* Utilities.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Utilities.html; path = docs/Utilities.html; sourceTree = "<group>"; };
+		5328D5DB37D343DA7968B285A8E1F3E9 /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
 		533834F563267CE8E4BC4A32FDDBC120 /* OIDAuthorizationRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDAuthorizationRequest.m; path = Source/OIDAuthorizationRequest.m; sourceTree = "<group>"; };
 		536525D7183A9515ADA1A18C70B56E48 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
 		53A075D724A1D27D580A7AD5960B3155 /* Data Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data Conversion.swift"; path = "sources/Data Conversion.swift"; sourceTree = "<group>"; };
@@ -770,12 +774,10 @@
 		556B923653E8429D5577DDBD6F0D5A6B /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
 		55AD42029E4580E161B5A1A52CD2F30C /* Exponentiation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Exponentiation.swift; path = sources/Exponentiation.swift; sourceTree = "<group>"; };
 		56097B565B5719EBD17A627426094B58 /* secp256k1_ec_mult_static_context.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ec_mult_static_context.h; path = secp256k1/Classes/secp256k1_ec_mult_static_context.h; sourceTree = "<group>"; };
-		566E5F1AC46CD3AB18072FFE27D4D0B8 /* Bitski-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Bitski-dummy.m"; sourceTree = "<group>"; };
-		5685E7CA645DF03CD48729A823AA387E /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
 		5735A353C79AA4280DDCCA3684C5FA85 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
 		57FE626C181A2D77767106785E8FDA20 /* OIDIDToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDIDToken.m; path = Source/OIDIDToken.m; sourceTree = "<group>"; };
 		580C3523D8A539AD350BC5B670F9F7A1 /* ContractPromiseExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContractPromiseExtensions.swift; path = Web3/Classes/ContractABI/Contract/ContractPromiseExtensions.swift; sourceTree = "<group>"; };
-		5A1AE722A293D5DFE5504D1A78B9664C /* BitskiAuthenticationAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiAuthenticationAgent.swift; sourceTree = "<group>"; };
+		581FF1F946FFA4F65B247DAAC35FEF15 /* TransactionWatcher.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = TransactionWatcher.html; path = docs/Classes/TransactionWatcher.html; sourceTree = "<group>"; };
 		5A4F345813E8A26C9E4F70E8F93BDEAB /* SolidityEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SolidityEvent.swift; path = Web3/Classes/ContractABI/Contract/SolidityEvent.swift; sourceTree = "<group>"; };
 		5A8E198F6EC1F65FB381829B94C371FD /* OIDServiceDiscovery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDServiceDiscovery.h; path = Source/OIDServiceDiscovery.h; sourceTree = "<group>"; };
 		5AF135BC7454FCBBB83C9B7830920D47 /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
@@ -787,17 +789,18 @@
 		5C0E0E87CAD90DABCB6C48C362EA0EFB /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
 		5C583BFDFCF9B743BFE3268CE492FDB6 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
 		5CBF1A00590ACFC958737DF265BC6087 /* Primitive Types.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Primitive Types.swift"; path = "SipHash/Primitive Types.swift"; sourceTree = "<group>"; };
+		5D0C6B0CC8B2F712D08B589C0638D163 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = docs/docsets/Bitski.docset/Contents/Info.plist; sourceTree = "<group>"; };
+		5D5F27AC3488E3D4A3398B474B6001D1 /* NetworkClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		5DBFD82D54AA879593D8EFB1B7AF8644 /* OIDTokenResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDTokenResponse.h; path = Source/OIDTokenResponse.h; sourceTree = "<group>"; };
 		5E6E5B7E2B4FA94715584D1735FD4238 /* hang.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = hang.m; path = Sources/hang.m; sourceTree = "<group>"; };
 		5FE5AA949275BD757130D43CEF454A2E /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/SafariServices.framework; sourceTree = DEVELOPER_DIR; };
 		5FFEA837FCE8DF51D0A9D481EFA6A310 /* OIDExternalUserAgentSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentSession.h; path = Source/OIDExternalUserAgentSession.h; sourceTree = "<group>"; };
 		608427808F04683EE5DBF3804B97333D /* Exports+Web3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Exports+Web3.swift"; path = "Web3/Classes/Core/Toolbox/Exports+Web3.swift"; sourceTree = "<group>"; };
-		60A7D20F29E34E54C47BCE69242E8FC6 /* BitskiHTTPProvider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = BitskiHTTPProvider.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/BitskiHTTPProvider.html; sourceTree = "<group>"; };
 		6356D9DD4EF074E7BE0DCDF66030B439 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
 		63E5C082DB7E8053C86AA5F32A64ED02 /* Web3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Web3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		64024AA1219D6C4B78F7DA5556C79D4E /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
 		64DCBBE4F4D5D555E4E14C39F93D6756 /* SolidityInvocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SolidityInvocation.swift; path = Web3/Classes/ContractABI/Contract/SolidityInvocation.swift; sourceTree = "<group>"; };
 		66AB80C2113954DDD50F3D764CEDB995 /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = BigInt/Classes/Strideable.swift; sourceTree = "<group>"; };
-		66BCC32E70DE13F3EBBD2BE778787A84 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/gh.png; sourceTree = "<group>"; };
 		68160E48AD6131198BD984EE7A733BFC /* OIDGrantTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDGrantTypes.m; path = Source/OIDGrantTypes.m; sourceTree = "<group>"; };
 		682E6F443CDF6003B1E2333CD1DFCA80 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
 		684043B1D3CFF6E3A99D5A2F97E8B10B /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
@@ -805,6 +808,8 @@
 		68994D064D49A4C2C46E13B38559A1DA /* AppAuth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AppAuth.h; path = Source/AppAuth.h; sourceTree = "<group>"; };
 		695FA613ADA67889EF9B4A2C355DE7F7 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
 		6995585BD8B0CC69EEECB0CBB670ED27 /* AppAuth.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AppAuth.xcconfig; sourceTree = "<group>"; };
+		6A627F606E83304B7463DD4945E1BF61 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
+		6AD16346145DE6DE954E144C7788AEAF /* Bitski-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Bitski-umbrella.h"; sourceTree = "<group>"; };
 		6B3D412DFC187C5D7A4A7FC9B6BA597C /* RLPItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLPItem.swift; path = Web3/Classes/Core/RLP/RLPItem.swift; sourceTree = "<group>"; };
 		6B3FAB79E9F9B2553AFD097BD72B12EF /* Division.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Division.swift; path = BigInt/Classes/Division.swift; sourceTree = "<group>"; };
 		6B456F53FA02293DC9D236966D30B84D /* num_gmp_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_gmp_impl.h; path = secp256k1/Classes/secp256k1/src/num_gmp_impl.h; sourceTree = "<group>"; };
@@ -812,38 +817,38 @@
 		6B7CA88F632C9D92DF72C2A971F67FBD /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomStringConvertible.swift; path = Sources/CustomStringConvertible.swift; sourceTree = "<group>"; };
 		6C1663AF012CAF0A01169B93C4964063 /* OHHTTPStubs.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubs.h; path = OHHTTPStubs/Sources/OHHTTPStubs.h; sourceTree = "<group>"; };
 		6C18A3011506520BD091D6AEA254E917 /* ecmult_const_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_const_impl.h; path = secp256k1/Classes/secp256k1/src/ecmult_const_impl.h; sourceTree = "<group>"; };
+		6CAAD5194623BCAD9223286EF15CD585 /* Authentication.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Authentication.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Authentication.html; sourceTree = "<group>"; };
+		6ECCD6D43C22282D8305CF3B3EA4AA05 /* TransactionWatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionWatcher.swift; sourceTree = "<group>"; };
 		6F2CB88E8D18D93C2A6C9C057CEFDFB8 /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F5C46F3E9DB7995EE4EB6BDF5215717 /* NSURLRequest+HTTPBodyTesting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+HTTPBodyTesting.m"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.m"; sourceTree = "<group>"; };
-		6FA4665EE5AC4F7030BE3BF249F12E62 /* TransactionWatcherDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = TransactionWatcherDelegate.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Protocols/TransactionWatcherDelegate.html; sourceTree = "<group>"; };
-		6FB754DD8D14C6DED4EEAC7B3D7A6B27 /* TransactionWatcher.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = TransactionWatcher.html; path = docs/Classes/TransactionWatcher.html; sourceTree = "<group>"; };
 		71F289D79DE695B57E7C08BC9C746D0F /* group_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = group_impl.h; path = secp256k1/Classes/secp256k1/src/group_impl.h; sourceTree = "<group>"; };
 		72793E0694B634AD8C12A8867C75A2AD /* race.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = race.m; path = Sources/race.m; sourceTree = "<group>"; };
 		73F27A18BC7FA00779D71DEBF1CE9212 /* field.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field.h; path = secp256k1/Classes/secp256k1/src/field.h; sourceTree = "<group>"; };
+		74D1929C623393A147FF5715CB647860 /* Bitski-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Bitski-dummy.m"; sourceTree = "<group>"; };
+		7500639E4F94A487BBAE2E03928C7698 /* Error.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Error.html; path = docs/Classes/BitskiHTTPProvider/Error.html; sourceTree = "<group>"; };
 		756D9F83FF53C4F41C1813307A1ADC4C /* num_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = num_impl.h; path = secp256k1/Classes/secp256k1/src/num_impl.h; sourceTree = "<group>"; };
 		76545A29E58982D75671F7C0A3915A06 /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = BigInt/Classes/Shifts.swift; sourceTree = "<group>"; };
 		7672BE439CB7CBD4248E4C837ECFB266 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
 		76E5B33C60DD6AEC968AAB88C9693474 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
 		7806C692718913987C6C548E3E9AF7D3 /* EthereumLogObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumLogObject.swift; path = Web3/Classes/Core/Json/EthereumLogObject.swift; sourceTree = "<group>"; };
 		79113BF9474EF2C0DA505AE267BA2493 /* EthereumValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumValue.swift; path = Web3/Classes/Core/Json/EthereumValue.swift; sourceTree = "<group>"; };
+		7948C90D7D542173F00449A968E83CA9 /* docSet.dsidx */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = docSet.dsidx; path = docs/docsets/Bitski.docset/Contents/Resources/docSet.dsidx; sourceTree = "<group>"; };
 		796A13E087EC5172EFD3D8A681CEF799 /* OIDDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDDefines.h; path = Source/OIDDefines.h; sourceTree = "<group>"; };
 		79CCF8F943E860BD647634D6E6592D55 /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = secp256k1/Classes/secp256k1/src/hash.h; sourceTree = "<group>"; };
 		79EEC3C012C0BA68CA3E7ACC6B9184BD /* SipHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SipHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFFDEDB8C756357CDD0779A61721838 /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catchable.swift; path = Sources/Catchable.swift; sourceTree = "<group>"; };
-		7B42BE132EC3117F12904FC597FE6DD8 /* Bitski+OIDAuthStateDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Bitski+OIDAuthStateDelegate.swift"; sourceTree = "<group>"; };
 		7BEE97874578880A7FBFA5774CBCEC5A /* PromiseKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-umbrella.h"; sourceTree = "<group>"; };
 		7C7ED01BBE3E6C8DD37E18A2D8B89CCC /* SipHasher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHasher.swift; path = SipHash/SipHasher.swift; sourceTree = "<group>"; };
 		7D1726C60707443DC931141815D80AA3 /* Pods-Bitski_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Bitski_Tests.modulemap"; sourceTree = "<group>"; };
-		7D1DCE886507510BF45DFCAFD7C39D6B /* Network.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Network.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski/Network.html; sourceTree = "<group>"; };
-		7DD3010E606D191D8C7A12A31E8B0F74 /* Bitski.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Bitski.html; path = docs/Classes/Bitski.html; sourceTree = "<group>"; };
-		7DE183BD52FE9818A54333717B38D0D7 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
 		7E60B2267F7E90A73524E94C6FDA2FA5 /* BigInt.swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt.swift-prefix.pch"; sourceTree = "<group>"; };
 		7ECA0F24352A3C6217B98CB3D95BB729 /* Pods-Bitski_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Bitski_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		7F39049CE7983063DE05FA548893054E /* TransactionWatcher.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = TransactionWatcher.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/TransactionWatcher.html; sourceTree = "<group>"; };
 		7FBA94C56F7D060E4F68E9EA730A146F /* ecmult_gen_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen_impl.h; path = secp256k1/Classes/secp256k1/src/ecmult_gen_impl.h; sourceTree = "<group>"; };
+		7FDAFACD42A1181960BB4BE75BC55B1A /* lunr.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = lunr.min.js; path = docs/js/lunr.min.js; sourceTree = "<group>"; };
 		80641C11EDD0DBD1CDDB73876CF6E5C3 /* OIDURLQueryComponent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDURLQueryComponent.m; path = Source/OIDURLQueryComponent.m; sourceTree = "<group>"; };
 		80AC92FDB1F57DB4CBC53B5AB3594A2A /* OIDAuthorizationService+IOS.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthorizationService+IOS.m"; path = "Source/iOS/OIDAuthorizationService+IOS.m"; sourceTree = "<group>"; };
 		80D8A660D827B2C759F8C6C3B747FDA3 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
-		82E0CC5D1F72E4C02F456330FBF2E4E4 /* Status.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Status.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/TransactionWatcher/Status.html; sourceTree = "<group>"; };
-		8368C5F9A037837F59E26E280BD91C53 /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = highlight.css; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/css/highlight.css; sourceTree = "<group>"; };
+		823DDA68C4D9C828A0BD8CB126225357 /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/dash.png; sourceTree = "<group>"; };
 		83A4D02D1CD7F1A1D926C535D7D7FE93 /* Exponentiation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Exponentiation.swift; path = BigInt/Classes/Exponentiation.swift; sourceTree = "<group>"; };
 		83AC229A5AE09E7BEB6A8C7A8DA7DDAD /* Pods-Bitski_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Bitski_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		8495C760351C39933C94A4F94DAAC06D /* scalar_low_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low_impl.h; path = secp256k1/Classes/secp256k1/src/scalar_low_impl.h; sourceTree = "<group>"; };
@@ -851,43 +856,43 @@
 		858045962765091627D71EC66D7528A3 /* Web3+PromiseKit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Web3+PromiseKit.swift"; path = "Web3/Classes/PromiseKit/Web3+PromiseKit.swift"; sourceTree = "<group>"; };
 		85CFAB96908ADC142955424E14539286 /* Web3.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Web3.modulemap; sourceTree = "<group>"; };
 		866095072D5E1918657EE6C4968D8048 /* BigInt.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = BigInt.xcconfig; sourceTree = "<group>"; };
-		88F113003A5F5B136703BBECA22B9AAE /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
 		8A37D8EC2C776EFD071F386425CFF195 /* SolidityFunction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SolidityFunction.swift; path = Web3/Classes/ContractABI/Contract/SolidityFunction.swift; sourceTree = "<group>"; };
-		8B2953EDFC7881D4FB2D047F1C910DB2 /* spinner.gif */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.gif; name = spinner.gif; path = docs/img/spinner.gif; sourceTree = "<group>"; };
+		8B426237F23EA3530C45BB303BBFFD59 /* TransactionWatcherDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = TransactionWatcherDelegate.html; path = docs/Protocols/TransactionWatcherDelegate.html; sourceTree = "<group>"; };
+		8B751225404FAAF4AE9CC870BC1445C5 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		8BAECE911EB4E6835E21EF83B1AC4DC5 /* EthereumQuantity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumQuantity.swift; path = Web3/Classes/Core/Json/EthereumQuantity.swift; sourceTree = "<group>"; };
 		8BB8AE467C36D9215B4CFED255BBF2B7 /* secp256k1.swift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "secp256k1.swift-prefix.pch"; sourceTree = "<group>"; };
 		8BBBF4F4A7B4EE050AA9ED13E11B1C5E /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
-		8D7C5E1F7103F6027DDDEED81AD3E11E /* AuthenticationError.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = AuthenticationError.html; path = docs/Classes/Bitski/AuthenticationError.html; sourceTree = "<group>"; };
+		8D3D3A2EFD886009F9E2E0023C73695D /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = highlight.css; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/css/highlight.css; sourceTree = "<group>"; };
 		8D84F37818EF7127B1A91BCB2B2E1029 /* OIDExternalUserAgentRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentRequest.h; path = Source/OIDExternalUserAgentRequest.h; sourceTree = "<group>"; };
 		8E0B78F9B0FB3554B72387DA2CDAFB3D /* OIDAuthState+IOS.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthState+IOS.m"; path = "Source/iOS/OIDAuthState+IOS.m"; sourceTree = "<group>"; };
-		8E8693F192A96FDDADBE45E86CEBA42E /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = search.json; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/search.json; sourceTree = "<group>"; };
+		8EEB1BB40AB15895A41CAED9BCF87E1A /* Network.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Network.html; path = docs/Classes/Bitski/Network.html; sourceTree = "<group>"; };
 		8F7CE98D53E529B2DA41AD5C873AE580 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
+		8FA188CEF4CBDBAEC55E1B7B50903167 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		9077BD92E076FE2A0FA268E7F6D169BA /* Bitski+Web3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Bitski+Web3.swift"; sourceTree = "<group>"; };
 		90D0530DFC23C37AF14144414981CBB7 /* OIDScopeUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDScopeUtilities.h; path = Source/OIDScopeUtilities.h; sourceTree = "<group>"; };
 		9196E0C8FEC57535701FD288D0D36DE4 /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
 		91D3FAD2A1C774E4D88E6140EBA8A714 /* Types+RLPItemConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Types+RLPItemConvertible.swift"; path = "Web3/Classes/Core/RLP/Types+RLPItemConvertible.swift"; sourceTree = "<group>"; };
 		91F5DE890BE397C7BBA95889D44695AB /* OHPathHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHPathHelpers.m; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.m; sourceTree = "<group>"; };
+		9234814CDB54F0016DFDA696E664056E /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jquery.min.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jquery.min.js; sourceTree = "<group>"; };
 		9258685EBDD6CE3289D3C9188C36CA75 /* OIDAuthorizationService+IOS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OIDAuthorizationService+IOS.h"; path = "Source/iOS/OIDAuthorizationService+IOS.h"; sourceTree = "<group>"; };
-		93930B4E6C4EFD9C48FA40184D3AB836 /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
 		9453B5EA76BC1DE094895414344D650D /* ABI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABI.swift; path = Web3/Classes/ContractABI/ABI/ABI.swift; sourceTree = "<group>"; };
 		94573028FBCA93D0DC3F776A6D5EB3A2 /* Multiplication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Multiplication.swift; path = sources/Multiplication.swift; sourceTree = "<group>"; };
 		945C96DD27333844C42B0D1FE7212647 /* Web3-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Web3-Info.plist"; sourceTree = "<group>"; };
 		94B4EBBE41D8D4521DFAF190F78EB170 /* OHHTTPStubs.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = OHHTTPStubs.modulemap; sourceTree = "<group>"; };
 		94F5FAE8BD88DB7BB4A89D3EA6E8D4F3 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
 		95675BF32A6FB18A4F9EE6D812F7A560 /* EthereumTransactionReceiptObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumTransactionReceiptObject.swift; path = Web3/Classes/Core/Json/EthereumTransactionReceiptObject.swift; sourceTree = "<group>"; };
-		95E47CED35D2A9271A32594A286D76F6 /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
 		966AD8278867B5D7B53FC09EB8534190 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
 		973F72E3F0CC74DC8A32060F7A3E0A65 /* Multiplication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Multiplication.swift; path = BigInt/Classes/Multiplication.swift; sourceTree = "<group>"; };
 		9761412F801A9A05113A62A02B5ADEAD /* OIDServiceConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDServiceConfiguration.h; path = Source/OIDServiceConfiguration.h; sourceTree = "<group>"; };
-		97DFDB97CF3A0BD8DC47BBC1327B28EA /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
 		982632EC9D55A6B9EB539218DA465EBF /* RLPEncoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RLPEncoder.swift; path = Web3/Classes/Core/RLP/RLPEncoder.swift; sourceTree = "<group>"; };
 		98480325FFD3F70E26CB8ACD00A93DF4 /* field_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_impl.h; path = secp256k1/Classes/secp256k1/src/field_impl.h; sourceTree = "<group>"; };
 		98AB9E3F6B154E054173EF618F29F9F5 /* basic-config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "basic-config.h"; path = "secp256k1/Classes/secp256k1/src/basic-config.h"; sourceTree = "<group>"; };
 		9A39A282357F7B73C85A2131A947F9EB /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
+		9A5F9E2AC45A0E6C4D37F0EC98389A0E /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = jazzy.css; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/css/jazzy.css; sourceTree = "<group>"; };
 		9A9FBEB0A3054416326644080E854949 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
 		9AA6C0362282DCBD4867F0BB6470DA92 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
 		9B64B65AE129A10129290B89F22175A0 /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
 		9BFCC6E9A89BB3557D4882A3339BF612 /* BigInt.swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "BigInt.swift-dummy.m"; sourceTree = "<group>"; };
-		9C2D1E449A5280C4744CB687F8CB0E23 /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/carat.png; sourceTree = "<group>"; };
 		9D0D58EC06A66A67DC90E8BCED8A955D /* field_10x26.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26.h; path = secp256k1/Classes/secp256k1/src/field_10x26.h; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9D98C57FEAFA6B582B3176D8225EFD60 /* ecmult_gen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_gen.h; path = secp256k1/Classes/secp256k1/src/ecmult_gen.h; sourceTree = "<group>"; };
@@ -897,6 +902,7 @@
 		A0030293708F3272A947584025C8C4D2 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
 		A00AA9812ECE66B4E0F9A7C79BD8B5BA /* EthereumAddress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumAddress.swift; path = Web3/Classes/Core/Transaction/EthereumAddress.swift; sourceTree = "<group>"; };
 		A05E4D71E45C370AE8930B16C3ED286C /* Comparable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Comparable.swift; path = BigInt/Classes/Comparable.swift; sourceTree = "<group>"; };
+		A0EE94C6C784757FB8A24EDACB254896 /* Network.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Network.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski/Network.html; sourceTree = "<group>"; };
 		A1185BB08852C4D931066BF7E582B2E3 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
 		A1B747871EAD46685D43E5B4F6CF2029 /* Eth+Contract.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Eth+Contract.swift"; path = "Web3/Classes/ContractABI/Contract/Eth+Contract.swift"; sourceTree = "<group>"; };
 		A2F6511A32371C04FBE280EB4BE2029D /* CharacterSet+Hex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CharacterSet+Hex.swift"; path = "Web3/Classes/Core/Toolbox/CharacterSet+Hex.swift"; sourceTree = "<group>"; };
@@ -905,8 +911,7 @@
 		A51E3BC1ADE8A0A20D135288987BB364 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
 		A521B757900B6FF95BCF9E36EDF95B55 /* AppAuth.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = AppAuth.modulemap; sourceTree = "<group>"; };
 		A56B53CEC5425498E7B02EE602C89560 /* SipHash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SipHash-dummy.m"; sourceTree = "<group>"; };
-		A6125A76B0639D6479C1C810A92C305A /* Bitski.tgz */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = Bitski.tgz; path = docs/docsets/Bitski.tgz; sourceTree = "<group>"; };
-		A6229EE8AF1D192D230ED358AECDDFF8 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jazzy.js; sourceTree = "<group>"; };
+		A5C8CA40D742D366A27E767FCEB97E18 /* typeahead.jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = typeahead.jquery.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/typeahead.jquery.js; sourceTree = "<group>"; };
 		A677727BC17C6EE4E46BF3A3C9F32077 /* field_5x52.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52.h; path = secp256k1/Classes/secp256k1/src/field_5x52.h; sourceTree = "<group>"; };
 		A702EEF552CCD2DD7C6E092669F26420 /* PromiseKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PromiseKit.xcconfig; sourceTree = "<group>"; };
 		A73636A971FA62238B64B687B0352F3A /* OIDAuthorizationResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDAuthorizationResponse.h; path = Source/OIDAuthorizationResponse.h; sourceTree = "<group>"; };
@@ -917,7 +922,6 @@
 		A7AFB9283FB49B52A0318148A2686906 /* Bytes+SecureRandom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bytes+SecureRandom.swift"; path = "Web3/Classes/Core/Toolbox/Bytes+SecureRandom.swift"; sourceTree = "<group>"; };
 		A8853B64CB87AAF1984E1983FFDD401E /* Pods_Bitski_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bitski_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A90896AC737FBBF78E7AF0E33EE26E54 /* secp256k1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = secp256k1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A98E7F9AF74D5C82A783F3AA0EC68ECA /* Error.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Error.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/BitskiHTTPProvider/Error.html; sourceTree = "<group>"; };
 		AA2C9F117D611330E621D1FA403BCFA7 /* OHHTTPStubs-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-umbrella.h"; sourceTree = "<group>"; };
 		AA7CE9C050BCE85D5B562ACB693EA859 /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Guarantee.swift; path = Sources/Guarantee.swift; sourceTree = "<group>"; };
 		AC651B5FCB131AD40E7F7DAB5DD427E2 /* OHHTTPStubs.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubs.m; path = OHHTTPStubs/Sources/OHHTTPStubs.m; sourceTree = "<group>"; };
@@ -925,17 +929,16 @@
 		ACD1D5324929DF1E01F618536307A6D1 /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = sources/Shifts.swift; sourceTree = "<group>"; };
 		ACFA693D171C3E31E0070BBF96E13822 /* OIDTokenUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDTokenUtilities.h; path = Source/OIDTokenUtilities.h; sourceTree = "<group>"; };
 		AD16728872F7B600FC88C8E53ECD2B47 /* Bitski.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bitski.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADAAF92774148CB5416D508411382626 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
 		ADDF993BC6F2063A8A4A6F70D7FF2880 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
 		AE2B9367D583D576D25C719EC191A692 /* Pods-Bitski_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Bitski_Example.modulemap"; sourceTree = "<group>"; };
 		AE3323506B9F80BEF58C12E509F721FB /* Secp256k1+CTXCreator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Secp256k1+CTXCreator.swift"; path = "Web3/Classes/Core/Toolbox/Secp256k1+CTXCreator.swift"; sourceTree = "<group>"; };
 		AE53BF1FA1DF83E0F1062390E72EB8F4 /* OIDTokenRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDTokenRequest.h; path = Source/OIDTokenRequest.h; sourceTree = "<group>"; };
 		AE8B7CA7D898BDD0FB4BF26F3D2E5627 /* UnsignedInteger+Shifting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UnsignedInteger+Shifting.swift"; path = "Web3/Classes/Core/Toolbox/UnsignedInteger+Shifting.swift"; sourceTree = "<group>"; };
 		AEC7A8BA321A09A4E57685AC832CC53D /* BigInt-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "BigInt-Info.plist"; sourceTree = "<group>"; };
-		AFB4AC7C9967CA400DD55AED5A38F37A /* Utilities.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Utilities.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Utilities.html; sourceTree = "<group>"; };
 		AFCEBF7ED37F399B42E939414065246E /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
 		B03619170E952239342C4429BED514E4 /* BigInt.swift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt.swift-umbrella.h"; sourceTree = "<group>"; };
 		B0B026CB700EFBBA6396E196430A0F53 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
-		B1138BAFD519E43C9F02832DD42CE65F /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
 		B12F7A540A56A5333251DAB6A9230E9E /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = sources/Strideable.swift; sourceTree = "<group>"; };
 		B14A1B038C564FA60D23A57A8A9E03C8 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
 		B1B64AEE3225ACB0D037DEFAEB2B3BE3 /* SipHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SipHashable.swift; path = SipHash/SipHashable.swift; sourceTree = "<group>"; };
@@ -943,25 +946,23 @@
 		B2F53AC52FC65F357FF4B2230143B3C0 /* GCD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCD.swift; path = sources/GCD.swift; sourceTree = "<group>"; };
 		B3B5F4C7F574C962F0209AC5FA6CD614 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
 		B3BD8C941A189B20A24BC031F20BB375 /* BitwiseOps.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BitwiseOps.swift; path = BigInt/Classes/BitwiseOps.swift; sourceTree = "<group>"; };
-		B40D469797AB83E2F2FC90BCFFB407D0 /* Authentication.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Authentication.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Authentication.html; sourceTree = "<group>"; };
 		B4477BDBEB5B426B896B852840DE007C /* RandomUInt64.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomUInt64.swift; path = SipHash/RandomUInt64.swift; sourceTree = "<group>"; };
 		B44D988379477544E4AB3DC3D783B490 /* OHHTTPStubsResponse+JSON.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubsResponse+JSON.h"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.h"; sourceTree = "<group>"; };
-		B46C162EFF0C5F71969705328CBEE472 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
 		B47563F0367C20BD8C477472B9C38EE8 /* BigInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigInt.swift; path = sources/BigInt.swift; sourceTree = "<group>"; };
+		B479DB97A2E4B633591E5CFCF671518F /* Watching Transactions.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = "Watching Transactions.html"; path = "docs/Watching Transactions.html"; sourceTree = "<group>"; };
 		B484A2A110BB713A676F6DD88A1F6246 /* OIDTokenRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDTokenRequest.m; path = Source/OIDTokenRequest.m; sourceTree = "<group>"; };
 		B55E1047B4ADC508F4478DBEFB5150FA /* ecmult_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecmult_impl.h; path = secp256k1/Classes/secp256k1/src/ecmult_impl.h; sourceTree = "<group>"; };
 		B56000A67F11F36A34BFB44BA71DFEAE /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
 		B569C6618253F4B0D39D25C7AB6753F9 /* Hashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Hashable.swift; path = BigInt/Classes/Hashable.swift; sourceTree = "<group>"; };
 		B5B602734BE1444BB29CDCE9575612C2 /* OIDExternalUserAgentIOSCustomBrowser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDExternalUserAgentIOSCustomBrowser.m; path = Source/iOS/OIDExternalUserAgentIOSCustomBrowser.m; sourceTree = "<group>"; };
 		B6743C01692F6313055C07E5923C0F8B /* EthereumPublicKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumPublicKey.swift; path = Web3/Classes/Core/Transaction/EthereumPublicKey.swift; sourceTree = "<group>"; };
-		B7F62B4A7CCAAC0D2298F2B94E7274DB /* Bitski.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Bitski.xcconfig; sourceTree = "<group>"; };
+		B756D693E45A2A6A351D94A122B230B4 /* Bitski.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Bitski.xcconfig; sourceTree = "<group>"; };
+		B788DBD83CEB0853BE14BF7677E14684 /* Bitski.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Bitski.modulemap; sourceTree = "<group>"; };
 		B83F95D999E8C66037377FFD18AFD696 /* PromiseKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PromiseKit-Info.plist"; sourceTree = "<group>"; };
 		B85128C5230DFA05AAFF5803A752C5CD /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
-		B86CA01B6292447413452CA4D1720CA6 /* docSet.dsidx */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = docSet.dsidx; path = docs/docsets/Bitski.docset/Contents/Resources/docSet.dsidx; sourceTree = "<group>"; };
-		B877199A8F613888766644239DBE04BF /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
-		B88C56FC3B81E429157C31A8BA8BB04C /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/dash.png; sourceTree = "<group>"; };
 		B8BEE8189473E2E79B1236CD485BDDB6 /* util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = util.h; path = secp256k1/Classes/secp256k1/src/util.h; sourceTree = "<group>"; };
 		B8ECA6389F559F910D52E09C7236C13C /* CryptoSwift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CryptoSwift-Info.plist"; sourceTree = "<group>"; };
+		B90D91929836D248424E191B89275F7A /* spinner.gif */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.gif; name = spinner.gif; path = docs/img/spinner.gif; sourceTree = "<group>"; };
 		BA6C7DE5847361FFD6D6AD0FADDC6F65 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
 		BA75BD93C43CAE38E2D1C15252D25020 /* ABIConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ABIConvertible.swift; path = Web3/Classes/ContractABI/ABI/ABIConvertible.swift; sourceTree = "<group>"; };
 		BAB02E4D4C45C6163156D4A21D9B31DA /* scalar_4x64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64.h; path = secp256k1/Classes/secp256k1/src/scalar_4x64.h; sourceTree = "<group>"; };
@@ -970,27 +971,30 @@
 		BD04ED9BF5CA56FA93B3F57B1876357F /* OIDScopeUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDScopeUtilities.m; path = Source/OIDScopeUtilities.m; sourceTree = "<group>"; };
 		BD2922FA7AB33ABFC439CA8DF0158798 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
 		BD48C5A6CEA16E96AC2123FDE6F317A8 /* OIDRegistrationResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDRegistrationResponse.m; path = Source/OIDRegistrationResponse.m; sourceTree = "<group>"; };
+		BD5B11BD333013ECB88D5F25A80D976E /* Bitski.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = Bitski.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BE364B5C73D2F6CF2C8678CAEC904076 /* Authentication.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Authentication.html; path = docs/Authentication.html; sourceTree = "<group>"; };
 		BE4505F79FDF6D00830D21BA8B4EBE9D /* Web3HttpProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Web3HttpProvider.swift; path = Web3/Classes/FoundationHTTP/Web3HttpProvider.swift; sourceTree = "<group>"; };
 		BE9FFFA71913FC812E8C247FED03E4E4 /* BigInt.swift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "BigInt.swift-Info.plist"; sourceTree = "<group>"; };
 		BF089B95F5F2CF9A8AAF77B604427114 /* OIDURLSessionProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDURLSessionProvider.m; path = Source/OIDURLSessionProvider.m; sourceTree = "<group>"; };
 		BF0D5EBDD27AD4B8B7B141600221EC3C /* Pods-Bitski_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Bitski_Example.release.xcconfig"; sourceTree = "<group>"; };
-		BF1A7065DAFA4C4F72BA548CA54991E0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		BF23EF2A652411DB5DCE502744BFE2AA /* fwd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fwd.h; path = Sources/fwd.h; sourceTree = "<group>"; };
-		C070FB852DF195245F39DD149E7A0AD1 /* TransactionWatcherDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = TransactionWatcherDelegate.html; path = docs/Protocols/TransactionWatcherDelegate.html; sourceTree = "<group>"; };
+		BF730023BF3A278E00AA596C16613BFA /* Watching Transactions.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = "Watching Transactions.html"; path = "docs/docsets/Bitski.docset/Contents/Resources/Documents/Watching Transactions.html"; sourceTree = "<group>"; };
+		C04688CF5518B45D7E2CC318D3435F32 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
 		C07D552AE193F8B9D33F787B53818CE6 /* Pods_Bitski_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Bitski_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0829F414355EFEA80F609279FC20378 /* BigInt-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BigInt-prefix.pch"; sourceTree = "<group>"; };
 		C0AF6538391051C10B0E9CA4F4261EC9 /* scratch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch.h; path = secp256k1/Classes/secp256k1/src/scratch.h; sourceTree = "<group>"; };
 		C14499F89076C2F2D82E055C4B4CB1B2 /* field_10x26_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_10x26_impl.h; path = secp256k1/Classes/secp256k1/src/field_10x26_impl.h; sourceTree = "<group>"; };
 		C15389599F303AEC177A5CF1FC1E9D96 /* Web3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Web3.swift; path = Web3/Classes/Core/Web3/Web3.swift; sourceTree = "<group>"; };
-		C154A5A5ABEBF74EA97F95555189B27D /* Watching Transactions.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = "Watching Transactions.html"; path = "docs/docsets/Bitski.docset/Contents/Resources/Documents/Watching Transactions.html"; sourceTree = "<group>"; };
 		C2E7DCDABBCCE39BF5A4149F10A9B3B1 /* OHHTTPStubs+NSURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubs+NSURLSessionConfiguration.m"; path = "OHHTTPStubs/Sources/NSURLSession/OHHTTPStubs+NSURLSessionConfiguration.m"; sourceTree = "<group>"; };
 		C3D7E51359A773FB7EDF8B6027FDD156 /* SipHash.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SipHash.modulemap; sourceTree = "<group>"; };
 		C404A9837419575DB173601AC34E950D /* OIDResponseTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDResponseTypes.h; path = Source/OIDResponseTypes.h; sourceTree = "<group>"; };
 		C40CFE54BE974C7318640767F792BD76 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
 		C4833CFEA34260639466F1430E11287A /* secp256k1.swift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "secp256k1.swift-Info.plist"; sourceTree = "<group>"; };
 		C4953586D8E95AE42DE002C5E6CBF90B /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4F2A158B378F77052CB39CFB17E0F9D /* Bitski.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Bitski.html; path = docs/Classes/Bitski.html; sourceTree = "<group>"; };
 		C55186C72814D9D47C340E95D2F6FF55 /* EthereumCall.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EthereumCall.swift; path = Web3/Classes/Core/Json/EthereumCall.swift; sourceTree = "<group>"; };
 		C5AEC25A50DF6B2754A247161F51D0D7 /* Floating Point Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Floating Point Conversion.swift"; path = "sources/Floating Point Conversion.swift"; sourceTree = "<group>"; };
+		C65559D1737D1AAD8C753A9AD847A0B8 /* Error.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Error.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/BitskiHTTPProvider/Error.html; sourceTree = "<group>"; };
 		C6C10C4872E85827C103893A7B8EE8E8 /* field_5x52_int128_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = field_5x52_int128_impl.h; path = secp256k1/Classes/secp256k1/src/field_5x52_int128_impl.h; sourceTree = "<group>"; };
 		C7FC4D96CEB9EC7220A7B29F8B4DC42A /* OIDRegistrationResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDRegistrationResponse.h; path = Source/OIDRegistrationResponse.h; sourceTree = "<group>"; };
 		C858CFECDC67959EEE208CE49FE74143 /* Web3Provider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Web3Provider.swift; path = Web3/Classes/Core/Providers/Web3Provider.swift; sourceTree = "<group>"; };
@@ -1001,7 +1005,6 @@
 		CA5AD28CE1DE2AB16E4DEC1318CBCEC1 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
 		CA6503492B80CDB4B92129558A2D45A4 /* Bytes+UInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bytes+UInt.swift"; path = "Web3/Classes/Core/Toolbox/Bytes+UInt.swift"; sourceTree = "<group>"; };
 		CA69EF61A20E49D5A0306C97BF007F91 /* scratch_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scratch_impl.h; path = secp256k1/Classes/secp256k1/src/scratch_impl.h; sourceTree = "<group>"; };
-		CBEA6F642274EB51E22E6C613023AD58 /* BitskiProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiProvider.swift; sourceTree = "<group>"; };
 		CC79FDCF745DD47B5EA7C5BC02B9DCB9 /* OIDExternalUserAgentIOSCustomBrowser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentIOSCustomBrowser.h; path = Source/iOS/OIDExternalUserAgentIOSCustomBrowser.h; sourceTree = "<group>"; };
 		CD0BC94E3397CA0F24FD9218F11AE65D /* Pods-Bitski_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Bitski_Example-Info.plist"; sourceTree = "<group>"; };
 		CDC2ACD9747CC7B701A439F655DE94B8 /* OIDRegistrationRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDRegistrationRequest.m; path = Source/OIDRegistrationRequest.m; sourceTree = "<group>"; };
@@ -1017,8 +1020,10 @@
 		D247FDBD818DAE92F9A4FA69B04ACED5 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D29ADCB525D3E9BA320C0F3DDE0A38F4 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
 		D2D188A981B5F72A0CFA327C792343BA /* ERC20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ERC20.swift; path = Web3/Classes/ContractABI/Contract/ERC20.swift; sourceTree = "<group>"; };
+		D3880E07AFC98EF97160164F2D79D676 /* BitskiHTTPProvider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = BitskiHTTPProvider.html; path = docs/Classes/BitskiHTTPProvider.html; sourceTree = "<group>"; };
 		D3BE60B0DC2F679ECBEEB3C41F648D70 /* SolidityType+Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SolidityType+Codable.swift"; path = "Web3/Classes/ContractABI/ABI/SolidityType+Codable.swift"; sourceTree = "<group>"; };
 		D3BF37B8B3BEF16BA70DD4793361D39C /* BigInt-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "BigInt-dummy.m"; sourceTree = "<group>"; };
+		D3F4093E3D3B641172D45A2A1145E2E8 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/gh.png; sourceTree = "<group>"; };
 		D45D16FDC753C4894557E017F3E7387B /* BigUInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigUInt.swift; path = sources/BigUInt.swift; sourceTree = "<group>"; };
 		D477D6F34171118CEF8807B35C4F05A7 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
 		D52E3CA20C05D922E35438AF7785D3F7 /* scalar_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_impl.h; path = secp256k1/Classes/secp256k1/src/scalar_impl.h; sourceTree = "<group>"; };
@@ -1027,16 +1032,14 @@
 		D75E984EE791E69A19C81A90B9765EC1 /* main_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = main_impl.h; path = secp256k1/Classes/secp256k1/src/modules/ecdh/main_impl.h; sourceTree = "<group>"; };
 		D82DACAECD008EE2B6DCD17699EF79C5 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8AFD8A594AA00F81AF7E07854B30EB0 /* eckey.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = eckey.h; path = secp256k1/Classes/secp256k1/src/eckey.h; sourceTree = "<group>"; };
+		D8C9E50E26168D2A111B814FF035563D /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
 		D9CB78190832C777F8DA7C937D01D2C5 /* OIDAuthState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDAuthState.h; path = Source/OIDAuthState.h; sourceTree = "<group>"; };
-		DAC2CE084215A465CF3081BE497A1C17 /* Bitski.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Bitski.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/Bitski.html; sourceTree = "<group>"; };
 		DB1B5AEC0AA36645E9A06973F0223BFE /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
 		DB24BE851A27D7D16E038AFE9FBDD539 /* Eth+ABI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Eth+ABI.swift"; path = "Web3/Classes/ContractABI/ABI/Eth+ABI.swift"; sourceTree = "<group>"; };
-		DB2B4E0B49FB87450FD007F70BC0C677 /* lunr.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = lunr.min.js; path = docs/js/lunr.min.js; sourceTree = "<group>"; };
 		DBFB5D9C589FEB3A6153A08E709B67CA /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
 		DC5645CE70AA5D95B5567857DFBE5164 /* Prime Test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Prime Test.swift"; path = "sources/Prime Test.swift"; sourceTree = "<group>"; };
 		DC715B4CAAB96FCA3E5936CDDB08691A /* OIDAuthorizationResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDAuthorizationResponse.m; path = Source/OIDAuthorizationResponse.m; sourceTree = "<group>"; };
 		DCB2E7BD58F0347EE7CF78B81B5422C8 /* OIDIDToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDIDToken.h; path = Source/OIDIDToken.h; sourceTree = "<group>"; };
-		DCFFBBBBF71E0A2B80F031A839C31607 /* jazzy.search.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.search.js; path = docs/js/jazzy.search.js; sourceTree = "<group>"; };
 		DD291A778A46C6FBC8BE7A054097E616 /* OHHTTPStubs-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "OHHTTPStubs-Info.plist"; sourceTree = "<group>"; };
 		DD53731F5D4ED510F0208D7FE75356AE /* secp256k1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1.h; path = secp256k1/Classes/secp256k1/include/secp256k1.h; sourceTree = "<group>"; };
 		DD631C7BA0040107A594CC114E04DE4B /* Pods-Bitski_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Bitski_Tests-frameworks.sh"; sourceTree = "<group>"; };
@@ -1045,9 +1048,8 @@
 		E014DC54C758893D25AB553171CE5571 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
 		E08499BC2D10EC549991CAA63E5941CB /* String+BytesConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+BytesConvertible.swift"; path = "Web3/Classes/Core/Toolbox/String+BytesConvertible.swift"; sourceTree = "<group>"; };
 		E0880E55B15B79D25BA7B4B84D6ED4F1 /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = firstly.swift; path = Sources/firstly.swift; sourceTree = "<group>"; };
-		E0B2788E401263CD70B41CF893898584 /* Error.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Error.html; path = docs/Classes/BitskiHTTPProvider/Error.html; sourceTree = "<group>"; };
+		E0A11BE51CAF93966001A3C17E758DAF /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = index.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/index.html; sourceTree = "<group>"; };
 		E0D649C17D911D2D44B4F6FFE360FD3F /* Pods-Bitski_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Bitski_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		E0DFBF4602D7AB67D4287D1C0C26389D /* lunr.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = lunr.min.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/lunr.min.js; sourceTree = "<group>"; };
 		E1541F71F63A18E5D0399837312E1BC8 /* Web3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Web3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E191E0EAA186463271B4A1617D14DBFA /* Addition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Addition.swift; path = sources/Addition.swift; sourceTree = "<group>"; };
 		E1B65212FD4D9C49BCDEFE04AD1299AB /* OIDTokenResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDTokenResponse.m; path = Source/OIDTokenResponse.m; sourceTree = "<group>"; };
@@ -1055,9 +1057,7 @@
 		E21CD1BCE7AD90FAC8BB2CA768CAD819 /* OIDFieldMapping.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDFieldMapping.h; path = Source/OIDFieldMapping.h; sourceTree = "<group>"; };
 		E2A07A2EE2D2FCE5CB9C9AEC58D3E0A5 /* IntegerConversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntegerConversion.swift; path = BigInt/Classes/IntegerConversion.swift; sourceTree = "<group>"; };
 		E312130B41D73E89A99467B044140F3C /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
-		E318D3F0CAFA4D8056E12FE37A5C81DD /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = docs/docsets/Bitski.docset/Contents/Info.plist; sourceTree = "<group>"; };
-		E3C2E5997BB46C611722EBA2DBAD630D /* RandomHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RandomHex.swift; sourceTree = "<group>"; };
-		E43BE8B9C01072FF4EEDE4BAE665D12B /* Bitski.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = Bitski.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		E33632A44A4F885BD54ABBC44FA2B450 /* jazzy.search.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jazzy.search.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/jazzy.search.js; sourceTree = "<group>"; };
 		E4428877D94A720B91367D81D014FAD6 /* BigInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigInt.swift; path = BigInt/Classes/BigInt.swift; sourceTree = "<group>"; };
 		E46CA322B4697FB9F8E8C9AA0B134E9F /* secp256k1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = secp256k1.c; path = secp256k1/Classes/secp256k1/src/secp256k1.c; sourceTree = "<group>"; };
 		E5C8C35B8882B88756D97295473516F8 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
@@ -1070,27 +1070,28 @@
 		E79110E768C3AEC6F96B9D9A39E5AF03 /* OIDResponseTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDResponseTypes.m; path = Source/OIDResponseTypes.m; sourceTree = "<group>"; };
 		E7AA2D41114AFE7E32E632D7A99080F0 /* WordsAndBits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WordsAndBits.swift; path = BigInt/Classes/WordsAndBits.swift; sourceTree = "<group>"; };
 		E7B0FCAE10440C4D78EFF352455FFFED /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Resolver.swift; path = Sources/Resolver.swift; sourceTree = "<group>"; };
+		E84EE33122AB23BE0035C62E /* TransactionSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSigner.swift; sourceTree = "<group>"; };
 		E85433A7935DE03173370D5F209333C5 /* OHHTTPStubsMethodSwizzling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsMethodSwizzling.h; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.h; sourceTree = "<group>"; };
-		E8D8CAD4225EC0B600AB575C /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
-		E9361392D7C332B76F5C1F5CF06234C2 /* Network.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Network.html; path = docs/Classes/Bitski/Network.html; sourceTree = "<group>"; };
 		E93769DC97ADA1987D1EF61E6DF9B38F /* OIDExternalUserAgentIOS.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OIDExternalUserAgentIOS.m; path = Source/iOS/OIDExternalUserAgentIOS.m; sourceTree = "<group>"; };
 		E9CD08511C19CF57191EAB66BABD2E3B /* String Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String Conversion.swift"; path = "sources/String Conversion.swift"; sourceTree = "<group>"; };
+		E9F8B5166E59DB4CC422CF71DD0F95CE /* BitskiAuthenticationAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiAuthenticationAgent.swift; sourceTree = "<group>"; };
 		EBF246F2D0138094B0831B0708746C21 /* OIDAuthorizationRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDAuthorizationRequest.h; path = Source/OIDAuthorizationRequest.h; sourceTree = "<group>"; };
 		EBF75594A3E1026E57067E5BC996EFA7 /* OHHTTPStubs-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-prefix.pch"; sourceTree = "<group>"; };
 		ECB1086A33013F7391C4D6856DB6050F /* Subtraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subtraction.swift; path = sources/Subtraction.swift; sourceTree = "<group>"; };
 		ED072A9D839B5B3F5F492800B2EA899C /* scalar_4x64_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_4x64_impl.h; path = secp256k1/Classes/secp256k1/src/scalar_4x64_impl.h; sourceTree = "<group>"; };
 		EDC023AB111D24FEEDBFA70A10D3D7D2 /* scalar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar.h; path = secp256k1/Classes/secp256k1/src/scalar.h; sourceTree = "<group>"; };
-		EDC8C5779A0CB7ADF3BFA8D36BDED061 /* Bitski.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Bitski.swift; sourceTree = "<group>"; };
 		EE65C5715EB5CDFB0A3BF8E65A243B23 /* Division.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Division.swift; path = sources/Division.swift; sourceTree = "<group>"; };
-		EEEEF83FD05EBA5EE98924B3A7AE4C30 /* TransactionWatcher.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = TransactionWatcher.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/TransactionWatcher.html; sourceTree = "<group>"; };
 		EF15AFFD5CCE3F2F61C17732675AAE96 /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
 		EF1CF31B5B6E7EC8A4320A59C5254CC4 /* AppAuth-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AppAuth-prefix.pch"; sourceTree = "<group>"; };
 		F11A9E9C79FF99554713A61ACB3B2807 /* BigInt.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = BigInt.modulemap; sourceTree = "<group>"; };
+		F2C802B914EAAA8849AAA140FDE3CF87 /* Bitski+OIDAuthStateDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Bitski+OIDAuthStateDelegate.swift"; sourceTree = "<group>"; };
 		F35032FCB9E2DE326EFFDEF538AC5794 /* Bytes+HexString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bytes+HexString.swift"; path = "Web3/Classes/Core/Toolbox/Bytes+HexString.swift"; sourceTree = "<group>"; };
 		F3801C55502DC10AB0354C6E288A00AD /* BigInt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BigInt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F386159D9CA220367D442FD3B59D3642 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
 		F3D869D3527617084C98CF2400C3CC2B /* Pods-Bitski_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Bitski_Tests-Info.plist"; sourceTree = "<group>"; };
 		F42638EA5309E54FB9BB5CC808EEF726 /* Square Root.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Square Root.swift"; path = "sources/Square Root.swift"; sourceTree = "<group>"; };
+		F44824D7B278FCEB026897E79F56D83D /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
+		F4EF787B64D0CB7946F2B13A701F73A6 /* Status.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = Status.html; path = docs/Classes/TransactionWatcher/Status.html; sourceTree = "<group>"; };
 		F523D40B1E8F6A137D5536218CF7A81A /* hash_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash_impl.h; path = secp256k1/Classes/secp256k1/src/hash_impl.h; sourceTree = "<group>"; };
 		F5350ED0DC45B84D4F3F0B62D0BD649F /* SipHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SipHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F56686287CCD49FF714B5439EACF1235 /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PromiseKit.modulemap; sourceTree = "<group>"; };
@@ -1099,17 +1100,19 @@
 		F6A1B048611F8BED9099D09B7E1CBBEB /* Data+BytesConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+BytesConvertible.swift"; path = "Web3/Classes/Core/Toolbox/Data+BytesConvertible.swift"; sourceTree = "<group>"; };
 		F819764598D0E1106D71B4721D67187A /* lax_der_parsing.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lax_der_parsing.c; path = secp256k1/Classes/secp256k1/contrib/lax_der_parsing.c; sourceTree = "<group>"; };
 		F84090BFF59F356C2BF0CFB5CBA4B393 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
-		F8617647093472681BA67A01A4C34AE8 /* BitskiAuthorizationAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BitskiAuthorizationAgent.swift; sourceTree = "<group>"; };
 		F96E8B51A500702373EAE87BD6EB26D0 /* StringConversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConversion.swift; path = BigInt/Classes/StringConversion.swift; sourceTree = "<group>"; };
 		F995DDFC83C919B3418829E1E109F1AA /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
-		FA14C7A4DFB33D0CC8966C69A7CA95BB /* Web3 Provider.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = "Web3 Provider.html"; path = "docs/Web3 Provider.html"; sourceTree = "<group>"; };
 		FA827899DE9CDBE894A97E3DC1F335F0 /* Pods-Bitski_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Bitski_Example-frameworks.sh"; sourceTree = "<group>"; };
 		FAA9366D0BC78D757C256ABDFFF93FF8 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
 		FAEDE6AA7DDDD2767E5F87BD9FAA2F94 /* ecdsa_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa_impl.h; path = secp256k1/Classes/secp256k1/src/ecdsa_impl.h; sourceTree = "<group>"; };
 		FB170ADAE77E9219B2050F28131F194E /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
+		FC5F6F502453F06B520B6BF3218F2010 /* Utilities.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Utilities.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Utilities.html; sourceTree = "<group>"; };
+		FC673204263A123B7794A32A2E2982EB /* lunr.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; name = lunr.min.js; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/js/lunr.min.js; sourceTree = "<group>"; };
+		FCA8196CFE2CF0F381CAC59A0C037B0F /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = search.json; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/search.json; sourceTree = "<group>"; };
 		FD9A2AA7E875C906F7BB8C209EB86B35 /* SipHash.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SipHash.xcconfig; sourceTree = "<group>"; };
 		FDD73D78EECAEC17E808490C40F72174 /* AppAuth-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "AppAuth-Info.plist"; sourceTree = "<group>"; };
 		FE1DF17A7DC85ADD2AB77212DD076A52 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
+		FE342D64BDB28778B120C9D0F3C4132F /* Status.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html.documentation; name = Status.html; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/Classes/TransactionWatcher/Status.html; sourceTree = "<group>"; };
 		FE81304779F5EA312711B9C62235C48B /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE95557F57556015F007394DC4D24333 /* secp256k1_ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = secp256k1_ecdh.h; path = secp256k1/Classes/secp256k1/include/secp256k1_ecdh.h; sourceTree = "<group>"; };
 		FEAD59A397657B4C8AFEAFBD439CEB04 /* secp256k1.swift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = secp256k1.swift.xcconfig; sourceTree = "<group>"; };
@@ -1117,31 +1120,28 @@
 		FF3891111ADEE1B61BD2CDC67521DBCC /* SipHash-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SipHash-umbrella.h"; sourceTree = "<group>"; };
 		FF5DDE3674312C83917BBD7C22D3F744 /* secp256k1.swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "secp256k1.swift-dummy.m"; sourceTree = "<group>"; };
 		FF601A4C09C272A73917799B6E52EA86 /* scalar_low.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scalar_low.h; path = secp256k1/Classes/secp256k1/src/scalar_low.h; sourceTree = "<group>"; };
+		FF885B8C7892789EF7F02C4028B90EEC /* spinner.gif */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.gif; name = spinner.gif; path = docs/docsets/Bitski.docset/Contents/Resources/Documents/img/spinner.gif; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		3635CA0CD5BFC34874BF2E47CA8BCBFF /* Frameworks */ = {
+		0C0E19EDAD22480CCF2D8DBBF3B6E823 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				329A3608AB84F04D743DD123EA9B7E64 /* BigInt.framework in Frameworks */,
-				C16A215C775EE299DE3C5DC34047CB7A /* CryptoSwift.framework in Frameworks */,
-				D54956504E7C594600DD77FF944A9536 /* Foundation.framework in Frameworks */,
-				C9FA6933511EFE345240197DB12E724B /* PromiseKit.framework in Frameworks */,
-				29A8C44EE0BECC808852FEC73C200D9B /* secp256k1.framework in Frameworks */,
+				B9E02A40EFD35EF80559FD5A5E37AD67 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		38E58F0E2AF7977EDB8005C2A2829BD6 /* Frameworks */ = {
+		3887429E123306A0317DDBE55853258A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F25D2E5AABCA6072976E0B9AE091F93 /* AppAuth.framework in Frameworks */,
-				24FFB8C0EED5619CD526E258ACEADC80 /* BigInt.framework in Frameworks */,
-				FCDDEA7211C8BD7FB202C5CC2D7370A3 /* Foundation.framework in Frameworks */,
-				0FAFE0E74FF2F4AB8C67EF03CA9E5CB4 /* PromiseKit.framework in Frameworks */,
-				C5FFA6A04591E99DA67B37FB65F71CFC /* secp256k1.framework in Frameworks */,
-				50205BFBB4BB37282683C1746E491944 /* Web3.framework in Frameworks */,
+				FDD99982B999A60D1B0EE3E8E76E3B6C /* AppAuth.framework in Frameworks */,
+				6325DFB73A010D122A86099739D8C82A /* BigInt.framework in Frameworks */,
+				F8C201AFC8D11F33A8346E7F0CCC7CC4 /* Foundation.framework in Frameworks */,
+				04AC9C6802BD16696F84B80864CFF8C8 /* PromiseKit.framework in Frameworks */,
+				B8E42C48B19520FB4B251FFD281AFAEA /* secp256k1.framework in Frameworks */,
+				4F307F24530BD02A2141315282860F25 /* Web3.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1154,28 +1154,12 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4A56223FE5849FD12D938781DE8E9D45 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				18F1AF655FFD3CB85FB5CAA20CC8CF8F /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		65AFBD9FBBFDA3060C552B1AF411C38B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				908DB48E8066721EACB8520E3687D5AA /* Foundation.framework in Frameworks */,
 				9F882C0FB4AA408854857E533402C38F /* SipHash.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7E44D60EC30B72B6F37B29829143634E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				88BB6556CD38495B2AE8EA2F48847DFE /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1188,11 +1172,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9111EB19525717358745B7EFE82408B6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1E8B73FBB8E980838711257F8FDDBAE6 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		94371186B5072EFFB554EA1D7BB458DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BA8738D271DCCDF455DA1E37E71F3AC8 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		959CEDDE9B1D5297A2F5593697EF4589 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC0444ABBBC0555C248A0EC65A4A84B2 /* BigInt.framework in Frameworks */,
+				316623AAA5EB720E713682DC2A004543 /* CryptoSwift.framework in Frameworks */,
+				0DD3824744038E06EEE0876B3768166D /* Foundation.framework in Frameworks */,
+				A4201850D27BA5879BC1BC2D6BBE0CF7 /* PromiseKit.framework in Frameworks */,
+				3225582BA1C09E52CB4394DD17951CCF /* secp256k1.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1212,11 +1216,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E52988C87637163E4826FD439B9B071E /* Frameworks */ = {
+		C36E62AF3BA999EAA84B25773DE07105 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1CE3306796F283C52C262794768C2518 /* Foundation.framework in Frameworks */,
+				6D07B79F0E8678DDF2F6CE193E688092 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1243,6 +1247,15 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/secp256k1.swift";
+			sourceTree = "<group>";
+		};
+		187A1EB2DFF3D9024B5A2A9673E8E75B /* AppAuth Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E9F8B5166E59DB4CC422CF71DD0F95CE /* BitskiAuthenticationAgent.swift */,
+			);
+			name = "AppAuth Extensions";
+			path = "Bitski/Classes/AppAuth Extensions";
 			sourceTree = "<group>";
 		};
 		1C8A83688A977E798997A8BFA1F21AAC /* PromiseKit */ = {
@@ -1384,6 +1397,16 @@
 			path = "Target Support Files/Pods-Bitski_Tests";
 			sourceTree = "<group>";
 		};
+		38FECA1170DC0E322282B697098B408C /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				23EB255B3DED4359AC89C3F0318CA21D /* RandomHex.swift */,
+				6ECCD6D43C22282D8305CF3B3EA4AA05 /* TransactionWatcher.swift */,
+			);
+			name = Utilities;
+			path = Bitski/Classes/Utilities;
+			sourceTree = "<group>";
+		};
 		3DD926CBAB795BE66E35F9741C15D5AA /* ContractABI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1408,19 +1431,6 @@
 				C8611F3AF86CBE734579AA892F583B80 /* SolidityWrappedValue.swift */,
 			);
 			name = ContractABI;
-			sourceTree = "<group>";
-		};
-		46308E8ADFF291F06D5DC9A18783E03F /* Bitski */ = {
-			isa = PBXGroup;
-			children = (
-				C8D833656E9F5EB8B7603EED646FD551 /* AppAuth Extensions */,
-				F68FB434E158C8DD8C4913632CB0FB1E /* Core */,
-				596218B0226AB9A0280FB1EA9A9D1234 /* Pod */,
-				C6858CD6FDA43BE66E602750C1A808BD /* Support Files */,
-				522B40EA3E863AAAC39ADB0BE45CBAB3 /* Utilities */,
-			);
-			name = Bitski;
-			path = ../..;
 			sourceTree = "<group>";
 		};
 		48CF6DCDF0787AAC44A10F2191B20B5D /* Core */ = {
@@ -1487,6 +1497,71 @@
 			path = "../Target Support Files/SipHash";
 			sourceTree = "<group>";
 		};
+		4B62306CEB4FB62902DFD9735D0D2355 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				BE364B5C73D2F6CF2C8678CAEC904076 /* Authentication.html */,
+				6CAAD5194623BCAD9223286EF15CD585 /* Authentication.html */,
+				434FCEC94C6AF5F8CB999187F0427C80 /* AuthenticationError.html */,
+				2D5167871B953490C3D6C18399B468FC /* AuthenticationError.html */,
+				5328D5DB37D343DA7968B285A8E1F3E9 /* badge.svg */,
+				00A68AC75C5F0B201721E72FE27EFD6B /* Bitski.html */,
+				C4F2A158B378F77052CB39CFB17E0F9D /* Bitski.html */,
+				BD5B11BD333013ECB88D5F25A80D976E /* Bitski.podspec */,
+				121A18E3926800928494A24DCE9CA540 /* Bitski.tgz */,
+				D3880E07AFC98EF97160164F2D79D676 /* BitskiHTTPProvider.html */,
+				0D7D51E8B7A94869F72EA30E5325E714 /* BitskiHTTPProvider.html */,
+				64024AA1219D6C4B78F7DA5556C79D4E /* carat.png */,
+				4F4093EFE5C5A9A89D62CFD333432FD0 /* carat.png */,
+				823DDA68C4D9C828A0BD8CB126225357 /* dash.png */,
+				4F05DAFFC8B03D69EE01CD873FFFB753 /* dash.png */,
+				7948C90D7D542173F00449A968E83CA9 /* docSet.dsidx */,
+				C65559D1737D1AAD8C753A9AD847A0B8 /* Error.html */,
+				7500639E4F94A487BBAE2E03928C7698 /* Error.html */,
+				2EC9662E0BF5E5694814040F4B98BB7E /* gh.png */,
+				D3F4093E3D3B641172D45A2A1145E2E8 /* gh.png */,
+				D8C9E50E26168D2A111B814FF035563D /* highlight.css */,
+				8D3D3A2EFD886009F9E2E0023C73695D /* highlight.css */,
+				6A627F606E83304B7463DD4945E1BF61 /* index.html */,
+				E0A11BE51CAF93966001A3C17E758DAF /* index.html */,
+				5D0C6B0CC8B2F712D08B589C0638D163 /* Info.plist */,
+				9A5F9E2AC45A0E6C4D37F0EC98389A0E /* jazzy.css */,
+				C04688CF5518B45D7E2CC318D3435F32 /* jazzy.css */,
+				2C8CBC8F97EEA3F18027476DCB138F40 /* jazzy.js */,
+				ADAAF92774148CB5416D508411382626 /* jazzy.js */,
+				3011013EEE54F21D56669D84C8F2FB69 /* jazzy.search.js */,
+				E33632A44A4F885BD54ABBC44FA2B450 /* jazzy.search.js */,
+				9234814CDB54F0016DFDA696E664056E /* jquery.min.js */,
+				F44824D7B278FCEB026897E79F56D83D /* jquery.min.js */,
+				8B751225404FAAF4AE9CC870BC1445C5 /* LICENSE */,
+				7FDAFACD42A1181960BB4BE75BC55B1A /* lunr.min.js */,
+				FC673204263A123B7794A32A2E2982EB /* lunr.min.js */,
+				8EEB1BB40AB15895A41CAED9BCF87E1A /* Network.html */,
+				A0EE94C6C784757FB8A24EDACB254896 /* Network.html */,
+				8FA188CEF4CBDBAEC55E1B7B50903167 /* README.md */,
+				FCA8196CFE2CF0F381CAC59A0C037B0F /* search.json */,
+				170E536A0B49B94A36324F6FA9A10913 /* search.json */,
+				FF885B8C7892789EF7F02C4028B90EEC /* spinner.gif */,
+				B90D91929836D248424E191B89275F7A /* spinner.gif */,
+				FE342D64BDB28778B120C9D0F3C4132F /* Status.html */,
+				F4EF787B64D0CB7946F2B13A701F73A6 /* Status.html */,
+				581FF1F946FFA4F65B247DAAC35FEF15 /* TransactionWatcher.html */,
+				7F39049CE7983063DE05FA548893054E /* TransactionWatcher.html */,
+				2C7A1B44B51D8F93BBFE230BF8B839A0 /* TransactionWatcherDelegate.html */,
+				8B426237F23EA3530C45BB303BBFFD59 /* TransactionWatcherDelegate.html */,
+				A5C8CA40D742D366A27E767FCEB97E18 /* typeahead.jquery.js */,
+				4EAF529C4E100BA6C72944600B7A89C9 /* typeahead.jquery.js */,
+				52FA2E16934FD0B56CDEE8BD59B99F4B /* undocumented.json */,
+				FC5F6F502453F06B520B6BF3218F2010 /* Utilities.html */,
+				531C4961F01E1F62EEA5D4C0B1B49A5D /* Utilities.html */,
+				B479DB97A2E4B633591E5CFCF671518F /* Watching Transactions.html */,
+				BF730023BF3A278E00AA596C16613BFA /* Watching Transactions.html */,
+				3BA1262E30AB183459F1DFAE4EC8BB03 /* Web3 Provider.html */,
+				52C06D2D25F2F9536401D2F2003B6F42 /* Web3 Provider.html */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
 		4F75DE782E5051BAEF6DB950FA0F2B6A /* CorePromise */ = {
 			isa = PBXGroup;
 			children = (
@@ -1518,16 +1593,6 @@
 				ADDF993BC6F2063A8A4A6F70D7FF2880 /* when.swift */,
 			);
 			name = CorePromise;
-			sourceTree = "<group>";
-		};
-		522B40EA3E863AAAC39ADB0BE45CBAB3 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				E3C2E5997BB46C611722EBA2DBAD630D /* RandomHex.swift */,
-				2C3CD13AD9D05719217B0BBB2CDBECBE /* TransactionWatcher.swift */,
-			);
-			name = Utilities;
-			path = Bitski/Classes/Utilities;
 			sourceTree = "<group>";
 		};
 		555B8513347AD4CC373764E8A6271BFB /* Pods-Bitski_Example */ = {
@@ -1645,69 +1710,20 @@
 			path = BigInt.swift;
 			sourceTree = "<group>";
 		};
-		596218B0226AB9A0280FB1EA9A9D1234 /* Pod */ = {
+		60B19B6C517CB44E2A511236D3AD7951 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				079ADA80BD6CBB7069C8FA6E9FACFF1A /* Authentication.html */,
-				B40D469797AB83E2F2FC90BCFFB407D0 /* Authentication.html */,
-				4E86D78516A045EAFC3E274B12385AB8 /* AuthenticationError.html */,
-				8D7C5E1F7103F6027DDDEED81AD3E11E /* AuthenticationError.html */,
-				95E47CED35D2A9271A32594A286D76F6 /* badge.svg */,
-				DAC2CE084215A465CF3081BE497A1C17 /* Bitski.html */,
-				7DD3010E606D191D8C7A12A31E8B0F74 /* Bitski.html */,
-				E43BE8B9C01072FF4EEDE4BAE665D12B /* Bitski.podspec */,
-				A6125A76B0639D6479C1C810A92C305A /* Bitski.tgz */,
-				0B16EB8BB0C57E386A2D125EBD0E6F7F /* BitskiHTTPProvider.html */,
-				60A7D20F29E34E54C47BCE69242E8FC6 /* BitskiHTTPProvider.html */,
-				93930B4E6C4EFD9C48FA40184D3AB836 /* carat.png */,
-				9C2D1E449A5280C4744CB687F8CB0E23 /* carat.png */,
-				B88C56FC3B81E429157C31A8BA8BB04C /* dash.png */,
-				88F113003A5F5B136703BBECA22B9AAE /* dash.png */,
-				B86CA01B6292447413452CA4D1720CA6 /* docSet.dsidx */,
-				A98E7F9AF74D5C82A783F3AA0EC68ECA /* Error.html */,
-				E0B2788E401263CD70B41CF893898584 /* Error.html */,
-				7DE183BD52FE9818A54333717B38D0D7 /* gh.png */,
-				66BCC32E70DE13F3EBBD2BE778787A84 /* gh.png */,
-				3CA5175BA7A9D1917B4A501F0462185A /* highlight.css */,
-				8368C5F9A037837F59E26E280BD91C53 /* highlight.css */,
-				97DFDB97CF3A0BD8DC47BBC1327B28EA /* index.html */,
-				11C71BA6287289ACD68A21282B11A442 /* index.html */,
-				E318D3F0CAFA4D8056E12FE37A5C81DD /* Info.plist */,
-				2DC0531FBD04AD0A2480D936FCC552F6 /* jazzy.css */,
-				B46C162EFF0C5F71969705328CBEE472 /* jazzy.css */,
-				A6229EE8AF1D192D230ED358AECDDFF8 /* jazzy.js */,
-				B1138BAFD519E43C9F02832DD42CE65F /* jazzy.js */,
-				DCFFBBBBF71E0A2B80F031A839C31607 /* jazzy.search.js */,
-				40F569C16A53C9EE37B5066CE53DC86D /* jazzy.search.js */,
-				488C317C55895E8A84B5E5F68D9AB1F2 /* jquery.min.js */,
-				2FA343DF75D24889AC82EF01C5B12DE7 /* jquery.min.js */,
-				BF1A7065DAFA4C4F72BA548CA54991E0 /* LICENSE */,
-				DB2B4E0B49FB87450FD007F70BC0C677 /* lunr.min.js */,
-				E0DFBF4602D7AB67D4287D1C0C26389D /* lunr.min.js */,
-				E9361392D7C332B76F5C1F5CF06234C2 /* Network.html */,
-				7D1DCE886507510BF45DFCAFD7C39D6B /* Network.html */,
-				1F738B1647E52516DEFACB833D0F3C4E /* README.md */,
-				8E8693F192A96FDDADBE45E86CEBA42E /* search.json */,
-				5685E7CA645DF03CD48729A823AA387E /* search.json */,
-				13E177C129856D31D78ECB069BE8DA90 /* spinner.gif */,
-				8B2953EDFC7881D4FB2D047F1C910DB2 /* spinner.gif */,
-				82E0CC5D1F72E4C02F456330FBF2E4E4 /* Status.html */,
-				1511A9EA6E89B004756466D72804C49B /* Status.html */,
-				6FB754DD8D14C6DED4EEAC7B3D7A6B27 /* TransactionWatcher.html */,
-				EEEEF83FD05EBA5EE98924B3A7AE4C30 /* TransactionWatcher.html */,
-				6FA4665EE5AC4F7030BE3BF249F12E62 /* TransactionWatcherDelegate.html */,
-				C070FB852DF195245F39DD149E7A0AD1 /* TransactionWatcherDelegate.html */,
-				29AEBF6AAF305B560ED18A13064706C4 /* typeahead.jquery.js */,
-				4B1C43A2E7C34457F5EA43662366DB4C /* typeahead.jquery.js */,
-				B877199A8F613888766644239DBE04BF /* undocumented.json */,
-				AFB4AC7C9967CA400DD55AED5A38F37A /* Utilities.html */,
-				2E85FF807AFE47AF75551DE19C3F2C1D /* Utilities.html */,
-				4CD43583EC09CD160903F218919513AC /* Watching Transactions.html */,
-				C154A5A5ABEBF74EA97F95555189B27D /* Watching Transactions.html */,
-				457A9270EBCDBA7939F85BCA57790ACE /* Web3 Provider.html */,
-				FA14C7A4DFB33D0CC8966C69A7CA95BB /* Web3 Provider.html */,
+				173CEA7A2979F36EFD73F65054B4B122 /* Bitski.swift */,
+				F2C802B914EAAA8849AAA140FDE3CF87 /* Bitski+OIDAuthStateDelegate.swift */,
+				9077BD92E076FE2A0FA268E7F6D169BA /* Bitski+Web3.swift */,
+				423569E307C93EECDB2618D13D01783F /* BitskiAuthorizationAgent.swift */,
+				2F6BF26B7D7741674D91B7B94EED1983 /* BitskiProvider.swift */,
+				150DA45616AFAB75349DAD331B95A9E5 /* BitskiTransaction.swift */,
+				5D5F27AC3488E3D4A3398B474B6001D1 /* NetworkClient.swift */,
+				E84EE33122AB23BE0035C62E /* TransactionSigner.swift */,
 			);
-			name = Pod;
+			name = Core;
+			path = Bitski/Classes/Core;
 			sourceTree = "<group>";
 		};
 		66681386BF5B750995E14F8E39B8D6BD /* PromiseKit */ = {
@@ -1737,7 +1753,7 @@
 		763B10F202A13A815DDFB990DF8644DE /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				46308E8ADFF291F06D5DC9A18783E03F /* Bitski */,
+				A8D15F8F74E38F2487DF145A1E528CC2 /* Bitski */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -1814,6 +1830,19 @@
 				91F5DE890BE397C7BBA95889D44695AB /* OHPathHelpers.m */,
 			);
 			name = OHPathHelpers;
+			sourceTree = "<group>";
+		};
+		A8D15F8F74E38F2487DF145A1E528CC2 /* Bitski */ = {
+			isa = PBXGroup;
+			children = (
+				187A1EB2DFF3D9024B5A2A9673E8E75B /* AppAuth Extensions */,
+				60B19B6C517CB44E2A511236D3AD7951 /* Core */,
+				4B62306CEB4FB62902DFD9735D0D2355 /* Pod */,
+				FE4C8C7A2F0377480BDC8329CC21B686 /* Support Files */,
+				38FECA1170DC0E322282B697098B408C /* Utilities */,
+			);
+			name = Bitski;
+			path = ../..;
 			sourceTree = "<group>";
 		};
 		A9A6EEA220EFAD5B2671AB45D96AAAFE /* HTTPExtension */ = {
@@ -1896,29 +1925,6 @@
 				058EE55622C25E73A5542CB4940C67B6 /* Support Files */,
 			);
 			path = secp256k1.swift;
-			sourceTree = "<group>";
-		};
-		C6858CD6FDA43BE66E602750C1A808BD /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				182F5F87BF189045F912FD2127C25A0B /* Bitski.modulemap */,
-				B7F62B4A7CCAAC0D2298F2B94E7274DB /* Bitski.xcconfig */,
-				566E5F1AC46CD3AB18072FFE27D4D0B8 /* Bitski-dummy.m */,
-				333F102CADB69540C44DC4078EABE3B8 /* Bitski-Info.plist */,
-				50E910011B4EA7272F7A9BFD5193BAF3 /* Bitski-prefix.pch */,
-				2423262B7C0F6B3E9B81F8C755EC3095 /* Bitski-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Bitski";
-			sourceTree = "<group>";
-		};
-		C8D833656E9F5EB8B7603EED646FD551 /* AppAuth Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				5A1AE722A293D5DFE5504D1A78B9664C /* BitskiAuthenticationAgent.swift */,
-			);
-			name = "AppAuth Extensions";
-			path = "Bitski/Classes/AppAuth Extensions";
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -2069,20 +2075,6 @@
 			path = CryptoSwift;
 			sourceTree = "<group>";
 		};
-		F68FB434E158C8DD8C4913632CB0FB1E /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				EDC8C5779A0CB7ADF3BFA8D36BDED061 /* Bitski.swift */,
-				7B42BE132EC3117F12904FC597FE6DD8 /* Bitski+OIDAuthStateDelegate.swift */,
-				F8617647093472681BA67A01A4C34AE8 /* BitskiAuthorizationAgent.swift */,
-				CBEA6F642274EB51E22E6C613023AD58 /* BitskiProvider.swift */,
-				4B02D530DFE0FD7924387B16EA5A70D9 /* BitskiTransaction.swift */,
-				E8D8CAD4225EC0B600AB575C /* NetworkClient.swift */,
-			);
-			name = Core;
-			path = Bitski/Classes/Core;
-			sourceTree = "<group>";
-		};
 		FADA46E961F3ADDB6E5F07128B51FB45 /* NSURLSession */ = {
 			isa = PBXGroup;
 			children = (
@@ -2095,9 +2087,31 @@
 			name = NSURLSession;
 			sourceTree = "<group>";
 		};
+		FE4C8C7A2F0377480BDC8329CC21B686 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B788DBD83CEB0853BE14BF7677E14684 /* Bitski.modulemap */,
+				B756D693E45A2A6A351D94A122B230B4 /* Bitski.xcconfig */,
+				74D1929C623393A147FF5715CB647860 /* Bitski-dummy.m */,
+				0DAE6ADBDD8AF654B9FD88CDD26CB2AA /* Bitski-Info.plist */,
+				152B25AF0B1430635B283B66150D3368 /* Bitski-prefix.pch */,
+				6AD16346145DE6DE954E144C7788AEAF /* Bitski-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Bitski";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		09CC5E9BE8A34FC3996AE39C161BF544 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E2819FAB33DB1EF7DB68E2C5C495B360 /* Web3-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1738904DFA435862B7A02C8B389C6FF1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2179,14 +2193,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5E16CBA1C3AD89BABD9F76C3C6EEEF18 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9AC2B8A7BBEBC610FCE7627AF91036B9 /* CryptoSwift-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6B23164803D3A76E1CF9F7FA7A730CF3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2195,22 +2201,67 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8D7B47E6A70490C3F9C710B74E582BBB /* Headers */ = {
+		A1479362415E3DFB27F05B66E26C6379 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9F9638E93F2467B6DCED9487B79F60B /* Bitski-umbrella.h in Headers */,
+				7AF2DFACE54B2DD224D58A48F1D9F6D7 /* Bitski-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B508402F608CDE730B6B6FB3C768008C /* Headers */ = {
+		BB0945F4C3C6DA5F75AAF0B93B1D5827 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB9E8045791215137E93285EFB97B760 /* AnyPromise.h in Headers */,
-				99D3FEB7D737D4A8747CE166216696ED /* fwd.h in Headers */,
-				9CC4C48EFC72BD7CC33B396F2BFC61A4 /* PromiseKit-umbrella.h in Headers */,
-				CAE12CA401E600ED019E392FA28D621B /* PromiseKit.h in Headers */,
+				08F7442858546590E96369BAE2277203 /* basic-config.h in Headers */,
+				8990B238003939FF31B08EAEE57C196D /* ecdsa.h in Headers */,
+				5F548F0F585C5F74E85A1E83A6AB104C /* ecdsa_impl.h in Headers */,
+				0AF954110B17542A0659E7243D7B932B /* eckey.h in Headers */,
+				4C9ACB4F588DE273FA2A14180A7CEAD3 /* eckey_impl.h in Headers */,
+				E73E6CE5C14D22AFE6321239AC5C586B /* ecmult.h in Headers */,
+				83DAA842390B030CBCDD4D75A947C77C /* ecmult_const.h in Headers */,
+				F0435E64FC29BE74A2EA9FB9E98524EC /* ecmult_const_impl.h in Headers */,
+				FF3DA16D708B4E6328BC66626D041229 /* ecmult_gen.h in Headers */,
+				76AA8190417BA4E1824E0DD4BA573D0A /* ecmult_gen_impl.h in Headers */,
+				E005A989B07347CD50548EB5EC529BA3 /* ecmult_impl.h in Headers */,
+				FB9D9CD334867D31C0365857A542C9FB /* field.h in Headers */,
+				915276A16E912255430E1A602CBD94EA /* field_10x26.h in Headers */,
+				D466ECE4366754BCE09506186CD48838 /* field_10x26_impl.h in Headers */,
+				5368ED7E926BF139A27934EB2156FD1F /* field_5x52.h in Headers */,
+				EC43D86815D5868E45DDC9CADFB3274F /* field_5x52_asm_impl.h in Headers */,
+				A6AFF826397C875D64D47A92023B43FC /* field_5x52_impl.h in Headers */,
+				94CE0210B79F52BDB6FDB1A5500FB369 /* field_5x52_int128_impl.h in Headers */,
+				786F2B5B0076333CAB6B602EFF270A84 /* field_impl.h in Headers */,
+				8778CA3E7C8A1A7303E8BADFAB4493F2 /* group.h in Headers */,
+				FBA1A3FE0F1A75EC61BC2CF8B06ACC1A /* group_impl.h in Headers */,
+				68A665D24370B2F6B7B137A87EB08386 /* hash.h in Headers */,
+				F827001487F442205D4CCECD6EF92244 /* hash_impl.h in Headers */,
+				5ECEFD24F085A79C5C36DB97D58E3F4B /* lax_der_parsing.h in Headers */,
+				856D02B5C3E2E1B268FA1045DCE31B5B /* lax_der_privatekey_parsing.h in Headers */,
+				BBE3662A330D02AB1727207B547257FD /* main_impl.h in Headers */,
+				E866F94C7F009FEA02901A777E191E8B /* main_impl.h in Headers */,
+				4DBA4353F71DD104BF985317651CCE6E /* num.h in Headers */,
+				1E90D5FB06D38A6FDC8846B71EB9FC5E /* num_gmp.h in Headers */,
+				77C8807407F338F58B4A822CB02344B6 /* num_gmp_impl.h in Headers */,
+				906AD94C6A83D577D897C8EFDDC92369 /* num_impl.h in Headers */,
+				9CB45020FBC9342F65E839F1A8B2AD4A /* scalar.h in Headers */,
+				F74AE36CA966937D65639FB7AAFC36A4 /* scalar_4x64.h in Headers */,
+				D6C3A43A470A89672CF1407C65A7F9E3 /* scalar_4x64_impl.h in Headers */,
+				A9069656FC483B318C6A0C2C1773D3D1 /* scalar_8x32.h in Headers */,
+				4D33E5DB9C123323BE2BC58D452617F3 /* scalar_8x32_impl.h in Headers */,
+				E897D9B129A66DEFED741BBD81E8AB86 /* scalar_impl.h in Headers */,
+				5F1112C1E499B15A44943EA38F826C1D /* scalar_low.h in Headers */,
+				7D5CC7759616EFFAED39EA7071400074 /* scalar_low_impl.h in Headers */,
+				89AEC4C946F9EE1F3BA8BF6496E5329B /* scratch.h in Headers */,
+				6B47D63C23394DC11FCFD76E70407A15 /* scratch_impl.h in Headers */,
+				83747708D3CF5F1049AE1D3CFCCE9292 /* secp256k1-config.h in Headers */,
+				67099506CE0401DDE83596612642CFCD /* secp256k1.h in Headers */,
+				FE6651104652572D4EF919CBD9C49DD7 /* secp256k1.swift-umbrella.h in Headers */,
+				ACE0E8B60F221F58964E37095C08EE15 /* secp256k1_ec_mult_static_context.h in Headers */,
+				DB9DAFFD08093BF656754C466E85F14D /* secp256k1_ecdh.h in Headers */,
+				73AF1E441052B42D52216B17772499BD /* secp256k1_main.h in Headers */,
+				5C773910076BFE172B5DB0C794510C15 /* secp256k1_recovery.h in Headers */,
+				A5CE09FC78F54112A8676B7F1EDDF766 /* util.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2222,67 +2273,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D5FD95D254B604B290EC65CDFB9C1604 /* Headers */ = {
+		E7B530340C2C217CFF3B64AF00523C99 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB9D48CB7F49B90E9E5BB7DD8D45220D /* basic-config.h in Headers */,
-				4C522E56B6C8248F37BDAD9BA9B96BCF /* ecdsa.h in Headers */,
-				890BB3FF0EA7E07F6842B3FB60B95D9D /* ecdsa_impl.h in Headers */,
-				4BB9B58B60F9D80BBBEC3D1A0E79F9DC /* eckey.h in Headers */,
-				7BC8016CA08A24BC512BC7B7751FDC6D /* eckey_impl.h in Headers */,
-				275172F4EAF1C2ED55E2F8B08DF2E80E /* ecmult.h in Headers */,
-				0298C3F0E570CB928C2CB7EB1EAD37E1 /* ecmult_const.h in Headers */,
-				CDB0791EABB35F3379C7F4278CCE63C5 /* ecmult_const_impl.h in Headers */,
-				1360A6E72D6A4D77287EF7491AFA528E /* ecmult_gen.h in Headers */,
-				BDE04804C641240348DC5A4F3B1AC639 /* ecmult_gen_impl.h in Headers */,
-				897FA17378D7494989271A43762C1DF2 /* ecmult_impl.h in Headers */,
-				0AD12990D029D92F559E4D434A2E8A66 /* field.h in Headers */,
-				E090C4E91BEF26A890496410FDFF54D0 /* field_10x26.h in Headers */,
-				486C22820CEB9EAB51C638C6899E2148 /* field_10x26_impl.h in Headers */,
-				01E960D0F4D41AEEE206E0E9BA3D3F9B /* field_5x52.h in Headers */,
-				675CE3E33C401D5BD8ADD7DCC9C5048A /* field_5x52_asm_impl.h in Headers */,
-				2DA7754537417935D2CDB4951C667087 /* field_5x52_impl.h in Headers */,
-				FFEB503E96658225E552161A332C8115 /* field_5x52_int128_impl.h in Headers */,
-				5143828B7AAA1C28D48CBB1EC251814A /* field_impl.h in Headers */,
-				7DD91953ECF377676FA206E5F717B048 /* group.h in Headers */,
-				9FFF88FC0543C328C072F53D9F98607B /* group_impl.h in Headers */,
-				2BAE3FD7BE6169946CDECAA734B15A31 /* hash.h in Headers */,
-				E50FED97D5345AB3A1CEA7CFDEB802F5 /* hash_impl.h in Headers */,
-				D0F9DEF82F6FC06DB976FAEEFA88C621 /* lax_der_parsing.h in Headers */,
-				2CE65C18CB037C33FA374F27F7D33D84 /* lax_der_privatekey_parsing.h in Headers */,
-				D71E0241C5994C85910E7585D56BA58B /* main_impl.h in Headers */,
-				2ACE83411C9CBBC7E1283D0284BE4747 /* main_impl.h in Headers */,
-				6C173B2024ED0B256024576080E1DF0C /* num.h in Headers */,
-				D7BFD9E87EBF8EBC4A8C6D4453D7AA38 /* num_gmp.h in Headers */,
-				D55A05DF3E4042AE3F082F7558F674D8 /* num_gmp_impl.h in Headers */,
-				9888671AAE54DB9D95F773F8C081AF14 /* num_impl.h in Headers */,
-				FEBF6245A58FB1F6E3822164DD5855A3 /* scalar.h in Headers */,
-				FA72799CB912037882CE07C43B2554A3 /* scalar_4x64.h in Headers */,
-				F7A9120F5F51AA0C0D25191BDCBE5E79 /* scalar_4x64_impl.h in Headers */,
-				62C2655E5B76BEAC3C60BA108BD58A71 /* scalar_8x32.h in Headers */,
-				382EB6ED08E7ED308B2CD16CD73F732E /* scalar_8x32_impl.h in Headers */,
-				611B7667C6BCCA6B4FD897A28F5B7EFB /* scalar_impl.h in Headers */,
-				8A0E32BEECD1EFB5244FE20A2137B45F /* scalar_low.h in Headers */,
-				B9ADF6E1C7C69A7CEC7A8005BDD0CD39 /* scalar_low_impl.h in Headers */,
-				39EF2A3EB0F1A6C3283918969F908E9A /* scratch.h in Headers */,
-				7A884BB6E5F56BE5D764781DF20CAEB1 /* scratch_impl.h in Headers */,
-				B121F66E8E96A88E09E0484B44112E15 /* secp256k1-config.h in Headers */,
-				5811C6E426D788181C5A13DB9DB50A21 /* secp256k1.h in Headers */,
-				CA202C7EA91003EBB166126274E5650E /* secp256k1.swift-umbrella.h in Headers */,
-				34156A2B69FAD65CA6CF88CC0D714999 /* secp256k1_ec_mult_static_context.h in Headers */,
-				F4ABBE7BBFD2B42A96BD98F9E0AD2AD4 /* secp256k1_ecdh.h in Headers */,
-				79E0636BE13900EEF655C6831232100F /* secp256k1_main.h in Headers */,
-				8422E41558883335D64187687467A39D /* secp256k1_recovery.h in Headers */,
-				87914C260C2F9CB463EDC36A150BEA63 /* util.h in Headers */,
+				D75F57B7979CD766F2671027083BB7B3 /* AnyPromise.h in Headers */,
+				434597CE94A5AD916BE489FD15D4775F /* fwd.h in Headers */,
+				863A7D13F3D2347C84B20B2127AA4054 /* PromiseKit-umbrella.h in Headers */,
+				1E4ADAF0EBCFDF7D2B530BB6865898F4 /* PromiseKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DEE0942946233C193678C952010974DC /* Headers */ = {
+		FB85F559E54B5B6743EBD22C1EE4D84B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				131C244A136E6968A871930E290C6871 /* Web3-umbrella.h in Headers */,
+				F4B9722E48EE4A1214F73B14144AEB14 /* CryptoSwift-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2328,21 +2334,21 @@
 		};
 		42672A41066C4682CBE265FBB44562B2 /* Bitski */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 15C267E7EDB4E12243B0248AC107A5E5 /* Build configuration list for PBXNativeTarget "Bitski" */;
+			buildConfigurationList = 0A8EAC297603760BC4A7178EBCEDA17A /* Build configuration list for PBXNativeTarget "Bitski" */;
 			buildPhases = (
-				8D7B47E6A70490C3F9C710B74E582BBB /* Headers */,
-				7E307A7477F90BDD42E3A7FFCD4CDD94 /* Sources */,
-				38E58F0E2AF7977EDB8005C2A2829BD6 /* Frameworks */,
-				A5E96352A6719A73ED9F6D8688ECE4BA /* Resources */,
+				A1479362415E3DFB27F05B66E26C6379 /* Headers */,
+				1E0948C0233FE93C5DEC9DF41D0CF79E /* Sources */,
+				3887429E123306A0317DDBE55853258A /* Frameworks */,
+				C799A95131A2A87FA1D6C9492E8CF872 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				5AD0D2054F34638D7E4378EBAA7B2235 /* PBXTargetDependency */,
-				76575E1DCBF62F21510F09349EDC6E4D /* PBXTargetDependency */,
-				3AE46372BD733F9E304DF972589F2C4F /* PBXTargetDependency */,
-				A17A449433567979A8ACB2773496C8AB /* PBXTargetDependency */,
-				783BDC67A7FA2BDCCFADFD00A60E5902 /* PBXTargetDependency */,
+				4EE7F5CB1534EC308D72474E9A92627E /* PBXTargetDependency */,
+				75871F57B5FA7C4F47F8893504C1934C /* PBXTargetDependency */,
+				8A8A697631398F738C6C71AF87B43240 /* PBXTargetDependency */,
+				32E7ACD9417F97F9196279308F776EDB /* PBXTargetDependency */,
+				E6479D8BB78E5873A379C27C664B43C6 /* PBXTargetDependency */,
 			);
 			name = Bitski;
 			productName = Bitski;
@@ -2351,12 +2357,12 @@
 		};
 		4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BB482E85510EA326103B8F885FA8F176 /* Build configuration list for PBXNativeTarget "secp256k1.swift" */;
+			buildConfigurationList = 113297CD4A9AAABE3C141DBBAB36ABF2 /* Build configuration list for PBXNativeTarget "secp256k1.swift" */;
 			buildPhases = (
-				D5FD95D254B604B290EC65CDFB9C1604 /* Headers */,
-				2DA7A46E8B43564D9D85F55BEE63DF2A /* Sources */,
-				E52988C87637163E4826FD439B9B071E /* Frameworks */,
-				1E62D6236434E43D2849CAC6BA19C6C4 /* Resources */,
+				BB0945F4C3C6DA5F75AAF0B93B1D5827 /* Headers */,
+				C6FAB6C12CE86D11936E0CFD700781BF /* Sources */,
+				0C0E19EDAD22480CCF2D8DBBF3B6E823 /* Frameworks */,
+				0F73C9B7865088E408ECD9FB2C435AC0 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2387,12 +2393,12 @@
 		};
 		7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0B4454D67408520DB12FB52A5B4656A6 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
+			buildConfigurationList = 579DF3D56940826170538BB766CA0BF8 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
 			buildPhases = (
-				B508402F608CDE730B6B6FB3C768008C /* Headers */,
-				F49B604EC92129D02F3AF83C7512CE6B /* Sources */,
-				4A56223FE5849FD12D938781DE8E9D45 /* Frameworks */,
-				934C9C6770FB6A78D3EC1450814BF614 /* Resources */,
+				E7B530340C2C217CFF3B64AF00523C99 /* Headers */,
+				3EA2CEF0BFEA9E6FC57213B71082396E /* Sources */,
+				C36E62AF3BA999EAA84B25773DE07105 /* Frameworks */,
+				EB514252CAB8A89333FDE6BD29DEEF21 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2432,12 +2438,12 @@
 		};
 		99313990C1D76A6D1D017868B6975CC8 /* CryptoSwift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8EC8A442446B0E8F79CE1E30A90FE81E /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
+			buildConfigurationList = A73FB42714F6BC6D998F01B3F1CD001C /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
 			buildPhases = (
-				5E16CBA1C3AD89BABD9F76C3C6EEEF18 /* Headers */,
-				91F3F9CD17B5F453A561390D0969A818 /* Sources */,
-				7E44D60EC30B72B6F37B29829143634E /* Frameworks */,
-				716A0BBCC4D5D4A852C2ADA6947D051E /* Resources */,
+				FB85F559E54B5B6743EBD22C1EE4D84B /* Headers */,
+				57188AEAA53BE7E741224F66F6D39B0D /* Sources */,
+				9111EB19525717358745B7EFE82408B6 /* Frameworks */,
+				A622013452F9456A4FAE76E4ECA4F8D9 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2514,20 +2520,20 @@
 		};
 		CC9BC1645C866B2D07A22D0A3EBF42CA /* Web3 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0449B37545D304C0B2D8A88A23868DB8 /* Build configuration list for PBXNativeTarget "Web3" */;
+			buildConfigurationList = DB03BA99D91377B58636A0393E5C1C69 /* Build configuration list for PBXNativeTarget "Web3" */;
 			buildPhases = (
-				DEE0942946233C193678C952010974DC /* Headers */,
-				93B7C9C2594622BD8B1BD3DEDDDFDE6A /* Sources */,
-				3635CA0CD5BFC34874BF2E47CA8BCBFF /* Frameworks */,
-				AE38336A6DBB42A01FC4FC681A4E8523 /* Resources */,
+				09CC5E9BE8A34FC3996AE39C161BF544 /* Headers */,
+				F1D836C83A0BC92BCF683313E03FD20B /* Sources */,
+				959CEDDE9B1D5297A2F5593697EF4589 /* Frameworks */,
+				FC57E75F43D0710E40593FB06D2C2497 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				EC2A62A0702150A3008CFE6241B43512 /* PBXTargetDependency */,
-				A73F3CC4D59AE8CD607C4D0BDEBFCF66 /* PBXTargetDependency */,
-				2ACBC2B125CDDF7570D83D9C6514FEA6 /* PBXTargetDependency */,
-				F4BBB054A8A670E10B6C95982109B16C /* PBXTargetDependency */,
+				C3D78457D663201948E75D6E1D4D9F30 /* PBXTargetDependency */,
+				14689F4578AE8F2BF709CA4B49FAAB0E /* PBXTargetDependency */,
+				4B5BE725E75B7166620088D184E4F271 /* PBXTargetDependency */,
+				90F634A7FA1D5EE480A1BCBAB6F9161C /* PBXTargetDependency */,
 			);
 			name = Web3;
 			productName = Web3;
@@ -2573,14 +2579,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		13AC8ABB6DCCCF32B386A8651AE0DB7E /* Resources */ = {
+		0F73C9B7865088E408ECD9FB2C435AC0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1E62D6236434E43D2849CAC6BA19C6C4 /* Resources */ = {
+		13AC8ABB6DCCCF32B386A8651AE0DB7E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2608,13 +2614,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		716A0BBCC4D5D4A852C2ADA6947D051E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		879EB344AD752C69A7CEA495A4005008 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2636,21 +2635,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		934C9C6770FB6A78D3EC1450814BF614 /* Resources */ = {
+		A622013452F9456A4FAE76E4ECA4F8D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A5E96352A6719A73ED9F6D8688ECE4BA /* Resources */ = {
+		C799A95131A2A87FA1D6C9492E8CF872 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AE38336A6DBB42A01FC4FC681A4E8523 /* Resources */ = {
+		EB514252CAB8A89333FDE6BD29DEEF21 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC57E75F43D0710E40593FB06D2C2497 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2676,14 +2682,53 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2DA7A46E8B43564D9D85F55BEE63DF2A /* Sources */ = {
+		1E0948C0233FE93C5DEC9DF41D0CF79E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B40AA005CE0553074CAA647C2320EFC4 /* lax_der_parsing.c in Sources */,
-				6126CF793DAFD5059F80457AB0FF4AEF /* lax_der_privatekey_parsing.c in Sources */,
-				81787F536B6E1ABE2D332C77D175EAB7 /* secp256k1.c in Sources */,
-				DEFCB948D5D33C78BC5DEED8333F88E4 /* secp256k1.swift-dummy.m in Sources */,
+				E84EE33222AB23BE0035C62E /* TransactionSigner.swift in Sources */,
+				7A19FB86B09C1E398AF8205C5238C16D /* Bitski+OIDAuthStateDelegate.swift in Sources */,
+				186D64249E2C8E00D7FF8C38592EC0CD /* Bitski+Web3.swift in Sources */,
+				E2BA621313767054F90255AF8369915E /* Bitski-dummy.m in Sources */,
+				F69EEEEDA62BF458233C98A5162352B6 /* Bitski.swift in Sources */,
+				361850E360F46660CB822B3C22F9F5FD /* BitskiAuthenticationAgent.swift in Sources */,
+				09C20BA41EA491E9AA14698E81F6F188 /* BitskiAuthorizationAgent.swift in Sources */,
+				879EE6FC2956AAB1CBF2130CCD14106D /* BitskiProvider.swift in Sources */,
+				543036112C1E2C00D483522B8A7B37C6 /* BitskiTransaction.swift in Sources */,
+				EBF44F39B37C77087D2B78CBECCF7CB3 /* NetworkClient.swift in Sources */,
+				F9E3FD3DD77271FEC3E5EE7D9BFF3E35 /* RandomHex.swift in Sources */,
+				C783EC1B67B931C69DA62D720B891430 /* TransactionWatcher.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EA2CEF0BFEA9E6FC57213B71082396E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4B5CA4344BEEE029807C2E56403526C2 /* after.m in Sources */,
+				299096096EB57C3935009E01D41501C5 /* after.swift in Sources */,
+				A76A29AA4FD2D9C2AF421E9332E1A3B3 /* AnyPromise.m in Sources */,
+				9843BC636C1499F7EE073449F89CD182 /* AnyPromise.swift in Sources */,
+				C41DDBE4ED265D3D12E9F8D45C0B703F /* Box.swift in Sources */,
+				5DE25363C9D441C14168F8EA038BDABF /* Catchable.swift in Sources */,
+				EE84C33E2031620275AD611B0E330B2A /* Configuration.swift in Sources */,
+				0F221C81ABAA8F837FD7317341FB5E21 /* CustomStringConvertible.swift in Sources */,
+				2376A3A5E848EB59D69644F69C29EF44 /* Deprecations.swift in Sources */,
+				146D071C100040BD8766D12D5CF0DDC2 /* dispatch_promise.m in Sources */,
+				6ECD10DDA988EE63C341D74AAD0CF6EA /* Error.swift in Sources */,
+				B5E3AF2133EF46C37DA2B17862EAE75B /* firstly.swift in Sources */,
+				DA2C0C8E4E972FAEC2350A905A17F6CD /* Guarantee.swift in Sources */,
+				6A97875F3AA511A691E27409EFB6467F /* hang.m in Sources */,
+				66CA386C7DA3864570E5591BFC12AE8B /* hang.swift in Sources */,
+				7F069C86D932A8C1988B7C734349D24E /* join.m in Sources */,
+				6699BF9AEA7A406C2E58D79452814D33 /* Promise.swift in Sources */,
+				C47688C1C0FE3F109715B7337DD220C0 /* PromiseKit-dummy.m in Sources */,
+				8F14B9D797267F4856D6F2B195C0CE57 /* race.m in Sources */,
+				30B4E8877010BF287F08AD4972D20710 /* race.swift in Sources */,
+				6145F30BE46E23C27C013ABF5A962B39 /* Resolver.swift in Sources */,
+				FA4A4F2C65DB75001527199FBB755B3A /* Thenable.swift in Sources */,
+				FFF1B2153862FBF3C5C5B2F886551ED8 /* when.m in Sources */,
+				BFADAFD8EAC0CBDF9408EC103B78AD42 /* when.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2729,20 +2774,82 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7E307A7477F90BDD42E3A7FFCD4CDD94 /* Sources */ = {
+		57188AEAA53BE7E741224F66F6D39B0D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6616265F933A818263B395286416B2F5 /* Bitski+OIDAuthStateDelegate.swift in Sources */,
-				E8D8CAD5225EC0B600AB575C /* NetworkClient.swift in Sources */,
-				EADCE42DB8F7D6086F55D877B541FC97 /* Bitski-dummy.m in Sources */,
-				D0257684613A5D2D297C3602D2AC1FBD /* Bitski.swift in Sources */,
-				9C462A4E44F9CA0EBDA70D1A2BAF5C8A /* BitskiAuthenticationAgent.swift in Sources */,
-				0F924E519F1C99F14B81F59B0A0E3753 /* BitskiAuthorizationAgent.swift in Sources */,
-				A55C977113000C7DE24606FDC49108BA /* BitskiProvider.swift in Sources */,
-				6E5A62AC7A905A8538511861BD68E68D /* BitskiTransaction.swift in Sources */,
-				B7AD102EF07B93D18EBAF81B5F8295E3 /* RandomHex.swift in Sources */,
-				B213AA6DC7C874D935FA3921284F99FE /* TransactionWatcher.swift in Sources */,
+				3A025C0384262F0B044E305F10BDD33F /* AEAD.swift in Sources */,
+				53D16A0A6BEC0016A1C0CED3111B917C /* AEADChaCha20Poly1305.swift in Sources */,
+				DC3C3320981A67BDDEC4A88C06B5FBB3 /* AES+Foundation.swift in Sources */,
+				13DD69E53349B0A5B988D7A099E3EF59 /* AES.Cryptors.swift in Sources */,
+				A76A4B2D2256ADF24961101ADC16866D /* AES.swift in Sources */,
+				336A5B17181C5E58B7FAC337F1CD4CCE /* Array+Extension.swift in Sources */,
+				9C6D4FEE82AC10C7C0C1611A16077A0F /* Array+Foundation.swift in Sources */,
+				4A2A362D21AE82D64E26EFD05F9C390A /* Authenticator.swift in Sources */,
+				2341612F58D32CD9D8442267AF010100 /* BatchedCollection.swift in Sources */,
+				D15E441F139F010319E06BC13F6B66B5 /* Bit.swift in Sources */,
+				5A425F5A0DB513EDD83E35739A42A78A /* BlockCipher.swift in Sources */,
+				67B4E5D9D0D90A8FFDF0232F3170D910 /* BlockDecryptor.swift in Sources */,
+				BBA125DE8A8236A284BDB9B47E5558AF /* BlockEncryptor.swift in Sources */,
+				3CD14756937D82BB4B0AB68D9D2201AD /* BlockMode.swift in Sources */,
+				73C3515308077FCF1D6935B314DA8DA0 /* BlockModeOptions.swift in Sources */,
+				B64F67AA7E9ECA7437AE45B288ADDB4D /* Blowfish+Foundation.swift in Sources */,
+				A0E0C1876F2022AD37598A4EC7AF4C4D /* Blowfish.swift in Sources */,
+				55197F1B539488C4D78D8897F42A81F4 /* CBC.swift in Sources */,
+				2B443D0FABEB50A77698A5948EE9A3B8 /* CFB.swift in Sources */,
+				D03119B1DB45FF25FCD560B5C77ABBF6 /* ChaCha20+Foundation.swift in Sources */,
+				E19BCA19773F1E62B8C72B2FAE0C6779 /* ChaCha20.swift in Sources */,
+				E0EF54997AF62999CD53364F40EADF14 /* Checksum.swift in Sources */,
+				3E4CFA813C8F0E702A5901B140674743 /* Cipher.swift in Sources */,
+				375016354C9AEDDED1ED9DE6D8FB18AB /* CipherModeWorker.swift in Sources */,
+				B72B299AF4116EFB8055D6E385FFF40F /* CMAC.swift in Sources */,
+				9A3C2BF9121D57065769B944C900F10C /* Collection+Extension.swift in Sources */,
+				1E26C406545971DF4710FAEA7D5E25F8 /* CompactMap.swift in Sources */,
+				8A4DD7590DD5110BA6BB0CBFA842A506 /* Cryptor.swift in Sources */,
+				FF0E0AB757B09C9394D75D194A6FBF84 /* Cryptors.swift in Sources */,
+				445BA964127D1DBB12E744B71092B60B /* CryptoSwift-dummy.m in Sources */,
+				6F36D683B6930474E864129F349CCDCD /* CTR.swift in Sources */,
+				2E67C60EC00B886E8949F103DF9FFD4E /* Data+Extension.swift in Sources */,
+				2CE246371017E85E736D4A2745540548 /* Digest.swift in Sources */,
+				B00D86DF4B5BC07933254391FD5DF509 /* DigestType.swift in Sources */,
+				3AFB2113D3AB2203F8FD5B242E150C3E /* ECB.swift in Sources */,
+				5D48259EEFA1A1957656009EBA8EB99F /* GCM.swift in Sources */,
+				7CBF40FE5E5C23F19CD7EF243EF19D02 /* Generics.swift in Sources */,
+				46A5A65875F55A885F8968FF50FC7178 /* HKDF.swift in Sources */,
+				EFDDA3F4B6CAD91D45500B8D93DDABB6 /* HMAC+Foundation.swift in Sources */,
+				F5FDBF795EB9338AFD45CB6B0DA98344 /* HMAC.swift in Sources */,
+				5A104832A4A49AD1B371F7E9957811BA /* Int+Extension.swift in Sources */,
+				FB2F9312A88E5D9137C4C52028D281CC /* MD5.swift in Sources */,
+				D4C3BB1E2DABE79A31E6C65EB289575A /* NoPadding.swift in Sources */,
+				E6E6D6D6CE9709D1B10D5A7AF7037845 /* OFB.swift in Sources */,
+				0B66E867684025387326123B1724E7F9 /* Operators.swift in Sources */,
+				D87531BFE26FADE1AF339E38EF9EA0B0 /* Padding.swift in Sources */,
+				9D3C78CC6D0F9D72FD8EC128EE21EDE0 /* PBKDF1.swift in Sources */,
+				EBE535946FCE1B10EEFA80088EE32020 /* PBKDF2.swift in Sources */,
+				1BE73ED62DD6C0F5B8CF2201C9EC7EB2 /* PCBC.swift in Sources */,
+				7B7D943CE82CBB3E69336801C1C48B2B /* PKCS5.swift in Sources */,
+				E2FB6F8368D1B999716EE5CEEF987C0D /* PKCS7.swift in Sources */,
+				EB4E7BAEA20C93F0B8E6C7015BBF3D82 /* PKCS7Padding.swift in Sources */,
+				FDA3DA1DF18693963061C04EF43B8637 /* Poly1305.swift in Sources */,
+				99DA3B5405D65BE89B1348F69C245909 /* Rabbit+Foundation.swift in Sources */,
+				8A26E5289978759034C09061CC82427D /* Rabbit.swift in Sources */,
+				774FB2CB790F0755BC1375BDFA93CB6B /* RandomBytesSequence.swift in Sources */,
+				C0025740A10C9821271C81615114D5B2 /* SecureBytes.swift in Sources */,
+				A971DE83EA07EDE50A4169AA38CB57D4 /* SHA1.swift in Sources */,
+				23D0609CBB9380032F01B8AB682624A8 /* SHA2.swift in Sources */,
+				2B410376EC00F5678A6D9775E2D4533D /* SHA3.swift in Sources */,
+				C917FA2EB6A047E2C2A2C2641CC910A1 /* StreamEncryptor.swift in Sources */,
+				4180A09861931E31A19FD63F8608B628 /* String+Extension.swift in Sources */,
+				B3F6DF71A2D2F00A5175EAA1645E8A3B /* String+FoundationExtension.swift in Sources */,
+				B5B5DAE307B4AFD0AD77009445822ADB /* UInt128.swift in Sources */,
+				33044B8732A00986251AA8B211544334 /* UInt16+Extension.swift in Sources */,
+				E2A8F044A1F10E6017C9AD0A40915DC4 /* UInt32+Extension.swift in Sources */,
+				26083FCE643B3A0967B2901D9C82737D /* UInt64+Extension.swift in Sources */,
+				3F3E715568A18AD15030BD9D42151C1D /* UInt8+Extension.swift in Sources */,
+				92F40686E055626CE106EE9C999F5109 /* Updatable.swift in Sources */,
+				06F95B44E6223CB143438F3E7A020FB4 /* Utils+Foundation.swift in Sources */,
+				3BAFBFC194C115B6CBFF3D5C458DEA03 /* Utils.swift in Sources */,
+				043570A44388483604ED2D812787E1A6 /* ZeroPadding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2755,160 +2862,6 @@
 				9B04407DFD3F92FF013BB02ADF2D7985 /* SipHash-dummy.m in Sources */,
 				4357E07CDCE76CE06C2D8211E6C2D505 /* SipHashable.swift in Sources */,
 				5B11A4362B4B72299B2BEA7DEE9D7574 /* SipHasher.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		91F3F9CD17B5F453A561390D0969A818 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E71E7E3BC0D7A67B8D7E57C225B07162 /* AEAD.swift in Sources */,
-				96ADF4DEC74E10AA0AA26E26C8813C14 /* AEADChaCha20Poly1305.swift in Sources */,
-				DAA9CEDCABCDF99E0866DF2B9049D1D9 /* AES+Foundation.swift in Sources */,
-				83484AFEC841E21DCF7F3A6FF41A301E /* AES.Cryptors.swift in Sources */,
-				046C83D63EA0997BE9021DEB77252D89 /* AES.swift in Sources */,
-				9620B2E95B7EE57907C511E8A238BF2A /* Array+Extension.swift in Sources */,
-				CC25E300D14D60D9D058270F53ACB898 /* Array+Foundation.swift in Sources */,
-				EFE8D215566AB1EBAE1E81F7F6F1C66C /* Authenticator.swift in Sources */,
-				EDAA902F8367B04B7407F7E83E00ADF3 /* BatchedCollection.swift in Sources */,
-				4B45BA8AC01CB904F24C1B80C3A964E2 /* Bit.swift in Sources */,
-				50C174FA26D8BE66019428486C6E306D /* BlockCipher.swift in Sources */,
-				CCF7D73E1FC3728438D376F5902EF37C /* BlockDecryptor.swift in Sources */,
-				25DADCC6EDA44DA0AC810114E9222D50 /* BlockEncryptor.swift in Sources */,
-				9A1BCFB8978227A5960058DEF3764A37 /* BlockMode.swift in Sources */,
-				1513A15EBCC10294414DB1301B90DE52 /* BlockModeOptions.swift in Sources */,
-				AD42F23D8B85D8B1F0477408B793A09C /* Blowfish+Foundation.swift in Sources */,
-				ACB8F46CCDC346C76BC63CEFBC1C1B3C /* Blowfish.swift in Sources */,
-				D80B42C3889AE086130A095C8985C83F /* CBC.swift in Sources */,
-				9754F1A4330D52490B20A9DC766660EB /* CFB.swift in Sources */,
-				97C41BA203E770B32FD17FBECBCF7400 /* ChaCha20+Foundation.swift in Sources */,
-				47836D25B89AC48D8AB5992CBB5B365C /* ChaCha20.swift in Sources */,
-				CA25403FBCCFBD0351D1F709104DB9AA /* Checksum.swift in Sources */,
-				A502976346010F175DD9C324353F851E /* Cipher.swift in Sources */,
-				BA302B3AA7A75A68E37A8FDF5D7E411C /* CipherModeWorker.swift in Sources */,
-				95D02365912094B13DB4595A3DDF88A4 /* CMAC.swift in Sources */,
-				9D52D4A208808AA539E3C694DE26149C /* Collection+Extension.swift in Sources */,
-				24EF78E14FEE520E8C98BA79EF30F4FE /* CompactMap.swift in Sources */,
-				4F5A55E0FABE61997E022A8600A2A7AD /* Cryptor.swift in Sources */,
-				0776BCE0B3FD420EC3BA5035E6CD5B9C /* Cryptors.swift in Sources */,
-				D5AB621379C2F3195AFC55869B2DE24E /* CryptoSwift-dummy.m in Sources */,
-				54C73FB21832C01789D0AB8A3F68DFD5 /* CTR.swift in Sources */,
-				5F8B2B86698462D8D60E6536E113B900 /* Data+Extension.swift in Sources */,
-				67C03F907B5AFF1F426C5B6406FB61F8 /* Digest.swift in Sources */,
-				EF13576CEA14B326148FB475C057A5CA /* DigestType.swift in Sources */,
-				165DE6A967B46023A72687F2204FBF4A /* ECB.swift in Sources */,
-				B355097AFE18F010FB167A592F410BB5 /* GCM.swift in Sources */,
-				D7540C2B86331D7DA6B4B25439F1772F /* Generics.swift in Sources */,
-				937BBB138480DC078E0DA2ECD0E2A113 /* HKDF.swift in Sources */,
-				BD1352B5D6C9341EEFAA2103504B5962 /* HMAC+Foundation.swift in Sources */,
-				E9832E991648225A46F9F0BC4435A649 /* HMAC.swift in Sources */,
-				80CF41B2091568F85EDB1FF392293944 /* Int+Extension.swift in Sources */,
-				F61ADFD2056937B365A976F5EEFAA58D /* MD5.swift in Sources */,
-				CE7055110B85971C57FD75E628D53FF2 /* NoPadding.swift in Sources */,
-				9C0871AF3EBBAF16A1855D05EB598734 /* OFB.swift in Sources */,
-				7B9DA4277987DC9C317187392E021CD9 /* Operators.swift in Sources */,
-				02B003D980C9000421EEB996E7FC2318 /* Padding.swift in Sources */,
-				96FA3D383E64FCB53CEC2E315AB3DF2B /* PBKDF1.swift in Sources */,
-				66FC4CE2B8BA53F6EAF6DF7A5EADD69C /* PBKDF2.swift in Sources */,
-				C41FE92746D003CE80EC182751D3BAA7 /* PCBC.swift in Sources */,
-				C7785CF346C358A316953E4B11DB9939 /* PKCS5.swift in Sources */,
-				958A6C22705FDA14D25E9C38BC1EBADE /* PKCS7.swift in Sources */,
-				78AB55627E566025AAD58D4AC0BDC0D6 /* PKCS7Padding.swift in Sources */,
-				4C687F9C2B2759CE0F59F837C4313C52 /* Poly1305.swift in Sources */,
-				FBF3588D2A4604AC0FEB90CB05BAE34A /* Rabbit+Foundation.swift in Sources */,
-				D57C7CC3F13760DA511AEB6FE0834655 /* Rabbit.swift in Sources */,
-				7E5498982F0C458C93228378BFD34767 /* RandomBytesSequence.swift in Sources */,
-				E35E8D2E207FA651114F184BBD51FE90 /* SecureBytes.swift in Sources */,
-				AA4DA496F382679305B7E4D058982582 /* SHA1.swift in Sources */,
-				8927A63192F5A5442441AE3ACA4E2FCF /* SHA2.swift in Sources */,
-				837B7F6314D5DFA602FE72C68CF7D6A2 /* SHA3.swift in Sources */,
-				50A357206654359639F6488C3C9641B6 /* StreamEncryptor.swift in Sources */,
-				3794437FBC4B9E3EDBCB3A46BF5A6CE5 /* String+Extension.swift in Sources */,
-				336D6FA88A72AE9A289052D76E8D0DE4 /* String+FoundationExtension.swift in Sources */,
-				0B48C89706B9EE9EBD2C930CD11AD4E6 /* UInt128.swift in Sources */,
-				628F1DC550FD5823D18A1F7E816FFB7A /* UInt16+Extension.swift in Sources */,
-				28C0C389131FF359F1C6AF2D09568A38 /* UInt32+Extension.swift in Sources */,
-				5A05AEE1333FBB490B5DEFEB83C7C4DB /* UInt64+Extension.swift in Sources */,
-				B8A5B9E3A68204781A277B1F1A415F52 /* UInt8+Extension.swift in Sources */,
-				7D7732B5130154B5115DACC51D2AC0F4 /* Updatable.swift in Sources */,
-				FB11CD7BCB55ADDA06B2498D8299C907 /* Utils+Foundation.swift in Sources */,
-				3486B6A76E757787188C43A217243C42 /* Utils.swift in Sources */,
-				104952E9036CB05B81A00F60B2D90B7A /* ZeroPadding.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		93B7C9C2594622BD8B1BD3DEDDDFDE6A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F22A7BA014B2E4DEA1F92A94815649D7 /* ABI.swift in Sources */,
-				CE910163B1EAF197A5377549BA061048 /* ABIConvertible.swift in Sources */,
-				2574A6D9A6A3FA0FF43BFE0D46B41882 /* ABIDecoder.swift in Sources */,
-				2802D2BF38E2D70FCD7B4461138A3634 /* ABIEncoder.swift in Sources */,
-				5C9BC6B290CED31877EB16BFADB255B9 /* ABIObject.swift in Sources */,
-				9895560B2521FF2E03A5884D6428861A /* BigUInt+BytesConvertible.swift in Sources */,
-				A5E6D5670630FB539ED0A0D13C97A9F7 /* Bytes+HexString.swift in Sources */,
-				55855BB64578CCDF18D6DFE02D77851A /* Bytes+SecureRandom.swift in Sources */,
-				208066A2AF3A56E2C1A15FF849D7CE89 /* Bytes+TrimLeadingZeros.swift in Sources */,
-				D4FB75F99F1759228540A9D741060C79 /* Bytes+UInt.swift in Sources */,
-				51774FE7C5E5A29A667599BD4312C01E /* BytesConvertible.swift in Sources */,
-				A0EC6EBE9812EA35E02188A1899BD5C5 /* CharacterSet+Hex.swift in Sources */,
-				D56DDE3437A8AE99133F3546CF120056 /* ContractPromiseExtensions.swift in Sources */,
-				3D409E8CBE3565FADBBA02107D42F1F0 /* Data+BytesConvertible.swift in Sources */,
-				549A0BBB0B16BC2313CCEF852385B2A7 /* ERC165.swift in Sources */,
-				6959696CC5ADA52DBB3CB6E428811C69 /* ERC20.swift in Sources */,
-				990AA208CE94EE55510AEA01CC77E00A /* ERC721.swift in Sources */,
-				E94DC06D7EFCA94CD044E0B1199380C8 /* Eth+ABI.swift in Sources */,
-				0E3E7F862A6BB18BA2A4CB063665B704 /* Eth+Contract.swift in Sources */,
-				A22D02CA4CA10154AE117C612265466C /* EthereumAddress.swift in Sources */,
-				210DC77E376BCBDE5FD04FBB6331DAAF /* EthereumBlockObject.swift in Sources */,
-				FDBA79EA05A72D7BD247077B6E7D39E7 /* EthereumCall.swift in Sources */,
-				F796F8367D1DA57157CA7F3AE7126C9E /* EthereumContract.swift in Sources */,
-				E12B0DF3B93803ECE3DE1ECAE11A1F03 /* EthereumData.swift in Sources */,
-				EF9EA719C32376DDA73FFFB353FD616F /* EthereumLogObject.swift in Sources */,
-				83168942A1CF269D8EAA4BBAC1BF2A73 /* EthereumPrivateKey.swift in Sources */,
-				6070B29B30D23955214EF666F7CAAFA8 /* EthereumPublicKey.swift in Sources */,
-				57AFC27629FCB00EBFCE97DB601C3932 /* EthereumQuantity.swift in Sources */,
-				90BADA1F4DE41BB89B9E03095DE609EE /* EthereumQuantityTag.swift in Sources */,
-				D325C22C0C28C48022BB5722D570B448 /* EthereumSyncStatusObject.swift in Sources */,
-				B45907D850EA9043309B222A913667A8 /* EthereumTransaction.swift in Sources */,
-				700A7BFC41F46D6DE2864CE26B27E5E7 /* EthereumTransactionObject.swift in Sources */,
-				BF7999EB96B7C7BE913716740FDEDB26 /* EthereumTransactionReceiptObject.swift in Sources */,
-				ECF67455E6305AAC3D477B5D730B427B /* EthereumValue.swift in Sources */,
-				21D821CF36134B7D275CA5BF1D446FB8 /* EthereumValueConvertible.swift in Sources */,
-				4C072D6C110B0C6F38B042C320843EAA /* Exports+PromiseKit.swift in Sources */,
-				A0DE99F7F144CF9EB6879840CF79A8D9 /* Exports+Web3.swift in Sources */,
-				755B5BBD15D3BC3102FC290C5F7DD378 /* Int+ETH.swift in Sources */,
-				CCC125F0B80A068A4554F97C6CF0D6ED /* Promisable.swift in Sources */,
-				43F02A1B6C8E00E65756A9A8221133A7 /* RLPDecoder.swift in Sources */,
-				1DBE5A7AFB064FB9EC6F6B1086F8B5B4 /* RLPEncoder.swift in Sources */,
-				A364636620EFEEC6F0487F682EF54025 /* RLPItem.swift in Sources */,
-				585FCD009CF3091870A66293F12BF3BD /* RLPItemConvertible.swift in Sources */,
-				7DB51DDBA6CF6681C510380E217A9086 /* RPCRequest.swift in Sources */,
-				426520E978A6EAF2A93FCBFAC2CA4AAC /* RPCResponse.swift in Sources */,
-				204732775A196B8BA7DC3DE0BF8B9304 /* Secp256k1+CTXCreator.swift in Sources */,
-				58689F22E7DF5C8F21DA6D37FFA3DC04 /* SolidityEvent.swift in Sources */,
-				C93D8A44C095377BEB032D2E034B43CF /* SolidityFunction.swift in Sources */,
-				FAA51A1081C22D64CED12C9C4EE03AD9 /* SolidityInvocation.swift in Sources */,
-				5BD5B97AAD25818710D0B8BC0A052D68 /* SolidityTuple.swift in Sources */,
-				01B5DBC0B30624E0DCAFA069A36DE928 /* SolidityType+Codable.swift in Sources */,
-				A8A52515BBD31780079232EA2979C562 /* SolidityType.swift in Sources */,
-				39EA11BFD9A0DC07F4B14AD855850242 /* SolidityWrappedValue.swift in Sources */,
-				DF93B61D4196512DAD766D3CD99E3191 /* String+BytesConvertible.swift in Sources */,
-				D46A4BEEB36AAA919CE7B905C00494AA /* String+Conversion.swift in Sources */,
-				4E16E8A8A178782609B6772035074175 /* String+HexBytes.swift in Sources */,
-				8A57A3966AA34E56A3FC75027C916EE8 /* Types+EthereumValueConvertible.swift in Sources */,
-				FB22BC377B6EEC4336DED94DA402BC82 /* Types+RLPItemConvertible.swift in Sources */,
-				3A478A651DDFD4C95EC24932B41EDB4D /* UInt+BytesRepresentable.swift in Sources */,
-				DEEB190E9FF6B65119C7DAB8786D6DFA /* UnsignedInteger+BytesConvertible.swift in Sources */,
-				7A0BB9B10E4CE0F6F2BE4038C166AF38 /* UnsignedInteger+Shifting.swift in Sources */,
-				078512706CB24BCE77B882F01323ED5B /* Values+GeneralHashable.swift in Sources */,
-				D9180D38BC36819DEF080D39605829B7 /* Web3+HTTPInitializer.swift in Sources */,
-				916BA37A11E16E10860BF0C425C15947 /* Web3+PromiseKit.swift in Sources */,
-				E22D907116DC355979955A97E61AC1AB /* Web3-dummy.m in Sources */,
-				49FBB097C4780D7DBA631D9715A6290B /* Web3.swift in Sources */,
-				D12E4D75404304828939FA1F53D17934 /* Web3HttpProvider.swift in Sources */,
-				5C28077523288FF969FFAFF30D7264FE /* Web3Provider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2950,6 +2903,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6FAB6C12CE86D11936E0CFD700781BF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A7F81C29F6B641AE19CD86F6327EA380 /* lax_der_parsing.c in Sources */,
+				878D4B989AE8C34ABD6388047D533F6B /* lax_der_privatekey_parsing.c in Sources */,
+				64E1B74797253469C9A63C9CF17F5065 /* secp256k1.c in Sources */,
+				EE35F66DCA11D7E8190A6C0562C1CB3D /* secp256k1.swift-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E7EC6FEB1BC28AF474ADC8A717580EA2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2980,34 +2944,78 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F49B604EC92129D02F3AF83C7512CE6B /* Sources */ = {
+		F1D836C83A0BC92BCF683313E03FD20B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F12A0380D9CD4E984BFC3A0527C85D3 /* after.m in Sources */,
-				21847663595D2C361282CA267269DF70 /* after.swift in Sources */,
-				E43E258712FA3091473C7CF8141ECAC1 /* AnyPromise.m in Sources */,
-				1915190FC7F42F85F11C5692AA16AA0C /* AnyPromise.swift in Sources */,
-				DAF46CD6BCC6A873F43F310B0777F27C /* Box.swift in Sources */,
-				2414EDF736667AD7F69E1C46FF1A8859 /* Catchable.swift in Sources */,
-				B487C304E4243537D941FA577E20676E /* Configuration.swift in Sources */,
-				BC57625B6A6D23D2066ED10A4879779F /* CustomStringConvertible.swift in Sources */,
-				F567EFF5EAE42C9819AD856BB8A0CB3E /* Deprecations.swift in Sources */,
-				A09CC4A410B6F61AB6840D8AFB63D954 /* dispatch_promise.m in Sources */,
-				0FD208782A5E5B8B63190830B3118FFE /* Error.swift in Sources */,
-				930F86D57C3604C7456592DF97C1E219 /* firstly.swift in Sources */,
-				C1FC067DF4C425283181E0349028FD26 /* Guarantee.swift in Sources */,
-				33DEBDD4E3F2A201B7408221213EEE5D /* hang.m in Sources */,
-				03A7079F9232960BCC86088B3CA4340C /* hang.swift in Sources */,
-				34D2C11B0E874E9E215F35DA178D9049 /* join.m in Sources */,
-				C156C3F22A587F124D1244BB6B77BE4F /* Promise.swift in Sources */,
-				EBB67B869EBFDE1B96BB534837843DF2 /* PromiseKit-dummy.m in Sources */,
-				19AFFF46CEEB326B7FCE7200B4D1E39B /* race.m in Sources */,
-				BB7A703186BA3A6528C67117E86F9756 /* race.swift in Sources */,
-				0F26766300CD4AA83FDF17312A1B276E /* Resolver.swift in Sources */,
-				A1DD426239D14486BBC4A0426FD04623 /* Thenable.swift in Sources */,
-				89EDED95B564D99D1D729A600F4424C3 /* when.m in Sources */,
-				B42480ABE52909FD07078031AB3C5316 /* when.swift in Sources */,
+				0919A426FFC6E05DFE23A5655D0E2985 /* ABI.swift in Sources */,
+				3615771E73CC654F70BA5628AAA6F915 /* ABIConvertible.swift in Sources */,
+				AD531C984C0C85E5674DD111292A6088 /* ABIDecoder.swift in Sources */,
+				7514D464CF7CAE125BFD86B720448DEF /* ABIEncoder.swift in Sources */,
+				414A8A6049102E11DD6EB6C520ECF7C2 /* ABIObject.swift in Sources */,
+				B4E7FBC7A15ADD85E00A54FD329C5337 /* BigUInt+BytesConvertible.swift in Sources */,
+				1273E10159BE193F30DFA65C06746514 /* Bytes+HexString.swift in Sources */,
+				88191F068E037C91A0C05BA5B5070118 /* Bytes+SecureRandom.swift in Sources */,
+				BC2DDC0A64CFAD8BE9D340BBC3A3EC46 /* Bytes+TrimLeadingZeros.swift in Sources */,
+				5791309BB74CC069EB3E3940744D138D /* Bytes+UInt.swift in Sources */,
+				4495F465597EC349E50230BCE66F8943 /* BytesConvertible.swift in Sources */,
+				36372BE1C73AE8821B37C61320FA730F /* CharacterSet+Hex.swift in Sources */,
+				8F4724F3D67B47E4577EB55E8A442FDF /* ContractPromiseExtensions.swift in Sources */,
+				FBE8E04E31C02459F3AD0BDE81A172CA /* Data+BytesConvertible.swift in Sources */,
+				6C31F243D76FD129B39713AE5978F4B9 /* ERC165.swift in Sources */,
+				E8866D0CAAD6C59E00326B60CDF21E78 /* ERC20.swift in Sources */,
+				A10513F639862EC6DCB07368844A708E /* ERC721.swift in Sources */,
+				DBA9A7279312E3BE94EC06C818C2B3D4 /* Eth+ABI.swift in Sources */,
+				83068C346B171BA7D7A7A400CD33F340 /* Eth+Contract.swift in Sources */,
+				7DA618CA36267C97083625E7216618BF /* EthereumAddress.swift in Sources */,
+				A451A148593C4FD561EEFBCFCB896712 /* EthereumBlockObject.swift in Sources */,
+				282E9D62EC6261F48995C103A304A54E /* EthereumCall.swift in Sources */,
+				CA4D9E0738986B77E48FF188E64BD0CA /* EthereumContract.swift in Sources */,
+				4EDC274BD69EBE21A56361E7725960D0 /* EthereumData.swift in Sources */,
+				D7B186F48D0FAACE37B1CE5D14AAEED6 /* EthereumLogObject.swift in Sources */,
+				CE128BAD80F1CC2E4C87B919A965F293 /* EthereumPrivateKey.swift in Sources */,
+				429F7AFEA71FDD17827F0BD48EAD5533 /* EthereumPublicKey.swift in Sources */,
+				EB1B73051EAA7B5CFA989AF6D4097CD5 /* EthereumQuantity.swift in Sources */,
+				4857D385DD120764FA5B577D9640EB68 /* EthereumQuantityTag.swift in Sources */,
+				8BAA35F5B79E143250B61E4B63C1EAC8 /* EthereumSyncStatusObject.swift in Sources */,
+				A0BD61035E7204D649A959CA76619035 /* EthereumTransaction.swift in Sources */,
+				0737AC64345A5EF2C190368F300011D9 /* EthereumTransactionObject.swift in Sources */,
+				1FAB570247F2134315D927E0CA1F2C50 /* EthereumTransactionReceiptObject.swift in Sources */,
+				F77FD61D0599DE8B5A4B69D5FC035088 /* EthereumValue.swift in Sources */,
+				531C361FC01431E96CA149F661D2700B /* EthereumValueConvertible.swift in Sources */,
+				8607AEF12677E2ADF261C4256404D10B /* Exports+PromiseKit.swift in Sources */,
+				00E14AA6FD4A16365F80ABBDE54132DC /* Exports+Web3.swift in Sources */,
+				35987B98FCD2D6AF5BEABED755EC8246 /* Int+ETH.swift in Sources */,
+				CDDFF974FE17B5627C5320E6C790FA59 /* Promisable.swift in Sources */,
+				758479D87828CCCB979BC01698635144 /* RLPDecoder.swift in Sources */,
+				C46D111322C86D1836922FF5705D2628 /* RLPEncoder.swift in Sources */,
+				3BC093AA9FEDCFE4F6F1A57A4C5249BE /* RLPItem.swift in Sources */,
+				5E2DEB1A40E8737F4CCE26A5768A63B0 /* RLPItemConvertible.swift in Sources */,
+				C6A142AF33F41E57DC768FC7D0845833 /* RPCRequest.swift in Sources */,
+				7FB49EEBAB04E31C2C78B829EE6C5C3D /* RPCResponse.swift in Sources */,
+				4043977D3214702A571C9B84024417E4 /* Secp256k1+CTXCreator.swift in Sources */,
+				895D6136D4B8B81B663CD4BB0140ADC1 /* SolidityEvent.swift in Sources */,
+				20CBE2BAFADB6A184A1741C08102E653 /* SolidityFunction.swift in Sources */,
+				5E40E4C05EED1C72DEC3B76E6C3E3E27 /* SolidityInvocation.swift in Sources */,
+				D441BAEB0678008C43F87610309A639B /* SolidityTuple.swift in Sources */,
+				534360E4753A79F8B95AAEF90DBFC38B /* SolidityType+Codable.swift in Sources */,
+				9C3A16A45708009C629DAEB820175700 /* SolidityType.swift in Sources */,
+				AE6AF0C5CC104C668200DF0B72E4C3F2 /* SolidityWrappedValue.swift in Sources */,
+				F2554B2C28F2843D2BDF68D9E8D6FDDC /* String+BytesConvertible.swift in Sources */,
+				280FCB894D39CBAD16C922D807E20B7A /* String+Conversion.swift in Sources */,
+				CB513027F2D8A878EAC880AC53345B69 /* String+HexBytes.swift in Sources */,
+				1732AAADBC86C8187D0C439DA70D7FDD /* Types+EthereumValueConvertible.swift in Sources */,
+				0F46D435F3A65ED96D733EA5B0482BB5 /* Types+RLPItemConvertible.swift in Sources */,
+				87ABD51A0DBDCD9983CA2C24B8C50CA3 /* UInt+BytesRepresentable.swift in Sources */,
+				77751EB9903BA7F3A44398795BC84BD6 /* UnsignedInteger+BytesConvertible.swift in Sources */,
+				4A9E9384FE146B5028DDE16968A49094 /* UnsignedInteger+Shifting.swift in Sources */,
+				113E0733E8E9ED3663F0B64AE74203FC /* Values+GeneralHashable.swift in Sources */,
+				2D0DEE07002C3F64FCE134AB04D250CB /* Web3+HTTPInitializer.swift in Sources */,
+				EA68A9282496E5087A52E66612FE35A3 /* Web3+PromiseKit.swift in Sources */,
+				5351D44D095E0F9861284DE914417D4B /* Web3-dummy.m in Sources */,
+				F888177A305F3A17F04576DE7C9975CC /* Web3.swift in Sources */,
+				8E5A5FC32B7F5F08BC8F3A2A44FC203D /* Web3HttpProvider.swift in Sources */,
+				56DA998A73C15ED90F613FFBB80D3004 /* Web3Provider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3020,17 +3028,23 @@
 			target = 5C642AA10FB29936669CC269F42079C6 /* AppAuth */;
 			targetProxy = 3DF8F1A7A1A80FD6D815525A113D5ADE /* PBXContainerItemProxy */;
 		};
+		14689F4578AE8F2BF709CA4B49FAAB0E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CryptoSwift;
+			target = 99313990C1D76A6D1D017868B6975CC8 /* CryptoSwift */;
+			targetProxy = 025717E3E3759D9BA87948A9FB344F0A /* PBXContainerItemProxy */;
+		};
 		1A9E336741155053952070AE8F71212A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PromiseKit;
 			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
 			targetProxy = 620F3D134E48DDA1BFA7FB95D0B76349 /* PBXContainerItemProxy */;
 		};
-		2ACBC2B125CDDF7570D83D9C6514FEA6 /* PBXTargetDependency */ = {
+		32E7ACD9417F97F9196279308F776EDB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = 2421D4433275BEAA005197250F366EE0 /* PBXContainerItemProxy */;
+			name = Web3;
+			target = CC9BC1645C866B2D07A22D0A3EBF42CA /* Web3 */;
+			targetProxy = 7740E4631A7C7B8743A601AAB37273F3 /* PBXContainerItemProxy */;
 		};
 		3927AEFB0461DE8D628438CABCDDF28A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3038,23 +3052,29 @@
 			target = C8CD155B863C8C242EE4BFB54258F488 /* BigInt.swift */;
 			targetProxy = CBC2C07C6028285EA529E63673CD2209 /* PBXContainerItemProxy */;
 		};
-		3AE46372BD733F9E304DF972589F2C4F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
-			targetProxy = 7B21DAEFFD83164E40570D6AC6F6BF70 /* PBXContainerItemProxy */;
-		};
 		43E4267E03711D2D555A73FE905EBC68 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Web3;
 			target = CC9BC1645C866B2D07A22D0A3EBF42CA /* Web3 */;
 			targetProxy = 33721D123E9FD1D07823A2A9F2EEA252 /* PBXContainerItemProxy */;
 		};
+		4B5BE725E75B7166620088D184E4F271 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
+			targetProxy = 4C99ACDBD332990083F49B7FFD80FE1A /* PBXContainerItemProxy */;
+		};
 		4B9BC431FCE91B48F7C49C96DCF05A49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CryptoSwift;
 			target = 99313990C1D76A6D1D017868B6975CC8 /* CryptoSwift */;
 			targetProxy = 2F52C7BF9614318770D2931A6A2160F6 /* PBXContainerItemProxy */;
+		};
+		4EE7F5CB1534EC308D72474E9A92627E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AppAuth;
+			target = 5C642AA10FB29936669CC269F42079C6 /* AppAuth */;
+			targetProxy = 49FBC3916BC049091978DCFC0E439B6D /* PBXContainerItemProxy */;
 		};
 		51CD06F80C5D2639565B8BAB1B40F444 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3067,12 +3087,6 @@
 			name = SipHash;
 			target = 377DAE4050D766B30C3A484B8525BB35 /* SipHash */;
 			targetProxy = 647986CEC0739B8A014F3AB4CF09A08F /* PBXContainerItemProxy */;
-		};
-		5AD0D2054F34638D7E4378EBAA7B2235 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AppAuth;
-			target = 5C642AA10FB29936669CC269F42079C6 /* AppAuth */;
-			targetProxy = F77C51DA60384F0063551DC39BB0EA1C /* PBXContainerItemProxy */;
 		};
 		5AEE870C1EA199727D1407490D01487D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3092,17 +3106,11 @@
 			target = 09DD83B7D075842A3A5105AD410BD38A /* BigInt */;
 			targetProxy = 33BA961718027E3723BC34E2315A3505 /* PBXContainerItemProxy */;
 		};
-		76575E1DCBF62F21510F09349EDC6E4D /* PBXTargetDependency */ = {
+		75871F57B5FA7C4F47F8893504C1934C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BigInt.swift;
 			target = C8CD155B863C8C242EE4BFB54258F488 /* BigInt.swift */;
-			targetProxy = 7C31D603D7421DCA3D3B79643B5EB3BF /* PBXContainerItemProxy */;
-		};
-		783BDC67A7FA2BDCCFADFD00A60E5902 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = secp256k1.swift;
-			target = 4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */;
-			targetProxy = F13E3F99762A2871B76B2185CDB8312D /* PBXContainerItemProxy */;
+			targetProxy = 9445698EBCF4B893980DDD15DDCEA2FD /* PBXContainerItemProxy */;
 		};
 		795C32DDEB2B23F4E31AC0392536E47D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3140,23 +3148,23 @@
 			target = 99313990C1D76A6D1D017868B6975CC8 /* CryptoSwift */;
 			targetProxy = 1717E2803D731D7E3DF6D8028D5DCF3B /* PBXContainerItemProxy */;
 		};
+		8A8A697631398F738C6C71AF87B43240 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 7C579CE66A1E7A9AA33CA5F97F9C22C5 /* PromiseKit */;
+			targetProxy = 544E88793A461286340B8416B53761AF /* PBXContainerItemProxy */;
+		};
+		90F634A7FA1D5EE480A1BCBAB6F9161C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = secp256k1.swift;
+			target = 4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */;
+			targetProxy = 8207C78E69E7F6D8D99A6ED320AEB8DB /* PBXContainerItemProxy */;
+		};
 		953C30D59E294CC7A2A0D2BC885F9A15 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AppAuth;
 			target = 5C642AA10FB29936669CC269F42079C6 /* AppAuth */;
 			targetProxy = 5FC101D3BF6DF156AD9CC9D77DAAEA19 /* PBXContainerItemProxy */;
-		};
-		A17A449433567979A8ACB2773496C8AB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Web3;
-			target = CC9BC1645C866B2D07A22D0A3EBF42CA /* Web3 */;
-			targetProxy = F51E15EDCA95669BF7F50FD8D90C6A6F /* PBXContainerItemProxy */;
-		};
-		A73F3CC4D59AE8CD607C4D0BDEBFCF66 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CryptoSwift;
-			target = 99313990C1D76A6D1D017868B6975CC8 /* CryptoSwift */;
-			targetProxy = 1F30164FFA5BF71FB96D0AFC85B96DDB /* PBXContainerItemProxy */;
 		};
 		B4AE0D99D67A8E796006FF9989DEE477 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3164,29 +3172,29 @@
 			target = 4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */;
 			targetProxy = 11240C592025CD323D40DFABD7307668 /* PBXContainerItemProxy */;
 		};
+		C3D78457D663201948E75D6E1D4D9F30 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BigInt;
+			target = 09DD83B7D075842A3A5105AD410BD38A /* BigInt */;
+			targetProxy = 3A5D36D30046036326C533AEBE09C5D1 /* PBXContainerItemProxy */;
+		};
 		D6C1C3DBD96D3C0EA7AAA1A97753712D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Bitski;
 			target = 42672A41066C4682CBE265FBB44562B2 /* Bitski */;
 			targetProxy = 46EFF439FD4490E69192857625208F6C /* PBXContainerItemProxy */;
 		};
-		EC2A62A0702150A3008CFE6241B43512 /* PBXTargetDependency */ = {
+		E6479D8BB78E5873A379C27C664B43C6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = BigInt;
-			target = 09DD83B7D075842A3A5105AD410BD38A /* BigInt */;
-			targetProxy = 3C7E21D451158F387896C82170856A8F /* PBXContainerItemProxy */;
+			name = secp256k1.swift;
+			target = 4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */;
+			targetProxy = EF3D552DA3105C68B77B8B639333AAE1 /* PBXContainerItemProxy */;
 		};
 		F2146FAF1663A66C8E467722D9AB9C94 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BigInt;
 			target = 09DD83B7D075842A3A5105AD410BD38A /* BigInt */;
 			targetProxy = 803B9169474978CC306ACB032BDE4B9C /* PBXContainerItemProxy */;
-		};
-		F4BBB054A8A670E10B6C95982109B16C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = secp256k1.swift;
-			target = 4FF1EE5493800BD023263DE462914B83 /* secp256k1.swift */;
-			targetProxy = BB4BA5006C23A591F50F2DA903A72027 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3256,72 +3264,6 @@
 			};
 			name = Debug;
 		};
-		15243C8CB97AE287C3233EB8BA6224D9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B7F62B4A7CCAAC0D2298F2B94E7274DB /* Bitski.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Bitski/Bitski-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Bitski/Bitski-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Bitski/Bitski.modulemap";
-				PRODUCT_MODULE_NAME = Bitski;
-				PRODUCT_NAME = Bitski;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		294480F9E0968EC278A630FBA21020A5 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FEAD59A397657B4C8AFEAFBD439CEB04 /* secp256k1.swift.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/secp256k1.swift/secp256k1.swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift.modulemap";
-				PRODUCT_MODULE_NAME = secp256k1;
-				PRODUCT_NAME = secp256k1;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		350C227BA2B10FC596596758817F50D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 83AC229A5AE09E7BEB6A8C7A8DA7DDAD /* Pods-Bitski_Example.debug.xcconfig */;
@@ -3357,6 +3299,38 @@
 			};
 			name = Debug;
 		};
+		360E0CE3853E6AE6FA768AAF0BD71D88 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FEAD59A397657B4C8AFEAFBD439CEB04 /* secp256k1.swift.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1.swift/secp256k1.swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1;
+				PRODUCT_NAME = secp256k1;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		3BEE380CA4D18AAE54781809D94D5F39 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 866095072D5E1918657EE6C4968D8048 /* BigInt.xcconfig */;
@@ -3383,39 +3357,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		3FCD7C783E579DC0E2100DB99FE41BC2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 25C427CB1221B5EB40E99FAFCAD6E95F /* Web3.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Web3/Web3-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Web3/Web3-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Web3/Web3.modulemap";
-				PRODUCT_MODULE_NAME = Web3;
-				PRODUCT_NAME = Web3;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -3511,6 +3452,73 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Release;
+		};
+		5DCAD8AFD42B059DB2D035ED1496E125 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B756D693E45A2A6A351D94A122B230B4 /* Bitski.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Bitski/Bitski-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Bitski/Bitski-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Bitski/Bitski.modulemap";
+				PRODUCT_MODULE_NAME = Bitski;
+				PRODUCT_NAME = Bitski;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		687E6A4E4CAE1FEC1984CBA16D180A1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A702EEF552CCD2DD7C6E092669F26420 /* PromiseKit.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				PRODUCT_MODULE_NAME = PromiseKit;
+				PRODUCT_NAME = PromiseKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -3710,40 +3718,7 @@
 			};
 			name = Debug;
 		};
-		8989C6EEC6D920B9CAA8CB435E6A8269 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 94F5FAE8BD88DB7BB4A89D3EA6E8D4F3 /* CryptoSwift.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift/CryptoSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CryptoSwift/CryptoSwift-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/CryptoSwift/CryptoSwift.modulemap";
-				PRODUCT_MODULE_NAME = CryptoSwift;
-				PRODUCT_NAME = CryptoSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		8AA92A5D326956049FB00D469DB6C172 /* Debug */ = {
+		8786335D22DC31F5EDBD42DD26E6B77E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 94F5FAE8BD88DB7BB4A89D3EA6E8D4F3 /* CryptoSwift.xcconfig */;
 			buildSettings = {
@@ -3774,6 +3749,71 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		8A3C47B447F839AB5097D874513C446A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A702EEF552CCD2DD7C6E092669F26420 /* PromiseKit.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				PRODUCT_MODULE_NAME = PromiseKit;
+				PRODUCT_NAME = PromiseKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		9834C05382EA8EBD459AC03B107F2626 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FEAD59A397657B4C8AFEAFBD439CEB04 /* secp256k1.swift.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/secp256k1.swift/secp256k1.swift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift.modulemap";
+				PRODUCT_MODULE_NAME = secp256k1;
+				PRODUCT_NAME = secp256k1;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 		994498140EFA99A32F378BC187413065 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3844,9 +3884,9 @@
 			};
 			name = Release;
 		};
-		C3339FB69EB9067B786C67CB6C20E1EE /* Release */ = {
+		B473B60E9608B6D9486294210C061715 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FEAD59A397657B4C8AFEAFBD439CEB04 /* secp256k1.swift.xcconfig */;
+			baseConfigurationReference = 25C427CB1221B5EB40E99FAFCAD6E95F /* Web3.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -3858,24 +3898,56 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/secp256k1.swift/secp256k1.swift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Web3/Web3-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Web3/Web3-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/secp256k1.swift/secp256k1.swift.modulemap";
-				PRODUCT_MODULE_NAME = secp256k1;
-				PRODUCT_NAME = secp256k1;
+				MODULEMAP_FILE = "Target Support Files/Web3/Web3.modulemap";
+				PRODUCT_MODULE_NAME = Web3;
+				PRODUCT_NAME = Web3;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
+		};
+		BC72952883B288AFC50F58A0D9FCC763 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B756D693E45A2A6A351D94A122B230B4 /* Bitski.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Bitski/Bitski-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Bitski/Bitski-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Bitski/Bitski.modulemap";
+				PRODUCT_MODULE_NAME = Bitski;
+				PRODUCT_NAME = Bitski;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		C74F77B38980F4BC022960B390C531F2 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3912,103 +3984,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		C7E2E07CFD6092732C6B1DC4E371A1A5 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B7F62B4A7CCAAC0D2298F2B94E7274DB /* Bitski.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Bitski/Bitski-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Bitski/Bitski-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Bitski/Bitski.modulemap";
-				PRODUCT_MODULE_NAME = Bitski;
-				PRODUCT_NAME = Bitski;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		C9BB9067BB9CAB077C794EA1BD22AD96 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A702EEF552CCD2DD7C6E092669F26420 /* PromiseKit.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				PRODUCT_MODULE_NAME = PromiseKit;
-				PRODUCT_NAME = PromiseKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		CBE937A5314052F4E0D9D62D84C8ADE4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 25C427CB1221B5EB40E99FAFCAD6E95F /* Web3.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Web3/Web3-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Web3/Web3-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Web3/Web3.modulemap";
-				PRODUCT_MODULE_NAME = Web3;
-				PRODUCT_NAME = Web3;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		D24007697098E4EA260D57C388F89512 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4075,9 +4050,9 @@
 			};
 			name = Release;
 		};
-		FFB9E2CD05B660D70A348AF85AF85683 /* Release */ = {
+		E711D2F256128C4ED93F3446B94F3F66 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A702EEF552CCD2DD7C6E092669F26420 /* PromiseKit.xcconfig */;
+			baseConfigurationReference = 94F5FAE8BD88DB7BB4A89D3EA6E8D4F3 /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "";
@@ -4089,14 +4064,47 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/PromiseKit-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/CryptoSwift/CryptoSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CryptoSwift/CryptoSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				PRODUCT_MODULE_NAME = PromiseKit;
-				PRODUCT_NAME = PromiseKit;
+				MODULEMAP_FILE = "Target Support Files/CryptoSwift/CryptoSwift.modulemap";
+				PRODUCT_MODULE_NAME = CryptoSwift;
+				PRODUCT_NAME = CryptoSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		E8A96407D7F8AFDE2C665C6607A94972 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 25C427CB1221B5EB40E99FAFCAD6E95F /* Web3.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Web3/Web3-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Web3/Web3-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Web3/Web3.modulemap";
+				PRODUCT_MODULE_NAME = Web3;
+				PRODUCT_NAME = Web3;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -4111,11 +4119,11 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0449B37545D304C0B2D8A88A23868DB8 /* Build configuration list for PBXNativeTarget "Web3" */ = {
+		0A8EAC297603760BC4A7178EBCEDA17A /* Build configuration list for PBXNativeTarget "Bitski" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CBE937A5314052F4E0D9D62D84C8ADE4 /* Debug */,
-				3FCD7C783E579DC0E2100DB99FE41BC2 /* Release */,
+				BC72952883B288AFC50F58A0D9FCC763 /* Debug */,
+				5DCAD8AFD42B059DB2D035ED1496E125 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4129,11 +4137,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0B4454D67408520DB12FB52A5B4656A6 /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
+		113297CD4A9AAABE3C141DBBAB36ABF2 /* Build configuration list for PBXNativeTarget "secp256k1.swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C9BB9067BB9CAB077C794EA1BD22AD96 /* Debug */,
-				FFB9E2CD05B660D70A348AF85AF85683 /* Release */,
+				360E0CE3853E6AE6FA768AAF0BD71D88 /* Debug */,
+				9834C05382EA8EBD459AC03B107F2626 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4147,20 +4155,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		15C267E7EDB4E12243B0248AC107A5E5 /* Build configuration list for PBXNativeTarget "Bitski" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C7E2E07CFD6092732C6B1DC4E371A1A5 /* Debug */,
-				15243C8CB97AE287C3233EB8BA6224D9 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6DFA1578582149B7E24AD55CBA30F07A /* Debug */,
 				4CE281642D6EE9FAB113046B4B6328A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		579DF3D56940826170538BB766CA0BF8 /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A3C47B447F839AB5097D874513C446A /* Debug */,
+				687E6A4E4CAE1FEC1984CBA16D180A1E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4183,15 +4191,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8EC8A442446B0E8F79CE1E30A90FE81E /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8AA92A5D326956049FB00D469DB6C172 /* Debug */,
-				8989C6EEC6D920B9CAA8CB435E6A8269 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		8F14CE148F2843DD27443C830A03FC55 /* Build configuration list for PBXNativeTarget "BigInt.swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4201,11 +4200,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BB482E85510EA326103B8F885FA8F176 /* Build configuration list for PBXNativeTarget "secp256k1.swift" */ = {
+		A73FB42714F6BC6D998F01B3F1CD001C /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				294480F9E0968EC278A630FBA21020A5 /* Debug */,
-				C3339FB69EB9067B786C67CB6C20E1EE /* Release */,
+				8786335D22DC31F5EDBD42DD26E6B77E /* Debug */,
+				E711D2F256128C4ED93F3446B94F3F66 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4224,6 +4223,15 @@
 			buildConfigurations = (
 				42772C7344500FFE1451802A2FB13294 /* Debug */,
 				750264642379680983E6522EBAD630F7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DB03BA99D91377B58636A0393E5C1C69 /* Build configuration list for PBXNativeTarget "Web3" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B473B60E9608B6D9486294210C061715 /* Debug */,
+				E8A96407D7F8AFDE2C665C6607A94972 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Tests/BitskiAuthorizationAgentTests.swift
+++ b/Example/Tests/BitskiAuthorizationAgentTests.swift
@@ -16,8 +16,9 @@ class BitskiAuthorizationAgentTests: XCTestCase {
         let authorizationExpectation = expectation(description: "Should recieve a callback")
         let url = URL(string: "https://sign.bitski.com")!
         let authAgent = BitskiAuthorizationAgent(baseURL: url, redirectURL: url)
-        authAgent.requestAuthorization(transactionId: "😏") { data, error in
-            XCTAssertNil(data)
+        authAgent.requestAuthorization(transactionId: "😏").done { data in
+            XCTFail()
+        }.catch { error in
             XCTAssertNotNil(error)
             authorizationExpectation.fulfill()
         }
@@ -28,8 +29,9 @@ class BitskiAuthorizationAgentTests: XCTestCase {
         let authorizationExpectation = expectation(description: "Should recieve a callback")
         let url = URL(string: "https://sign.bitski.com")!
         let authAgent = BitskiAuthorizationAgent(baseURL: url, redirectURL: url, authorizationClass: MockEmptyURLAuthorizationSession.self)
-        authAgent.requestAuthorization(transactionId: UUID().uuidString) { data, error in
-            XCTAssertNil(data)
+        authAgent.requestAuthorization(transactionId: UUID().uuidString).done { data in
+            XCTFail()
+        }.catch { error in
             XCTAssertNotNil(error)
             authorizationExpectation.fulfill()
         }
@@ -40,8 +42,9 @@ class BitskiAuthorizationAgentTests: XCTestCase {
         let authorizationExpectation = expectation(description: "Should recieve a callback")
         let url = URL(string: "https://sign.bitski.com")!
         let authAgent = BitskiAuthorizationAgent(baseURL: url, redirectURL: url, authorizationClass: MockAuthorizationSession.self)
-        authAgent.requestAuthorization(transactionId: UUID().uuidString) { data, error in
-            XCTAssertNil(data)
+        authAgent.requestAuthorization(transactionId: UUID().uuidString).done { data in
+            XCTFail()
+        }.catch { error in
             XCTAssertNotNil(error)
             authorizationExpectation.fulfill()
         }

--- a/Example/Tests/BitskiTransactionTests.swift
+++ b/Example/Tests/BitskiTransactionTests.swift
@@ -33,44 +33,4 @@ class BitskiTransactionTests: XCTestCase {
         let arbitraryKind = BitskiTransaction<String>.Kind(methodName: "eth_accounts")
         XCTAssertNil(arbitraryKind)
     }
-
-    func testCreateSignPayload() {
-        do {
-            let address = try EthereumAddress(hex: "0xF4A2CB946f72e1460C490bF490E73d81295130cd", eip55: false)
-            let data = EthereumData(bytes: "hello world".bytes)
-            let message = MessageSignatureObject(from: address, message: data)
-            XCTAssertEqual(message.from, address)
-            XCTAssertEqual(message.message, data)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-    
-    func testCreateSignPayloadFromParams() {
-        do {
-            let address = try EthereumAddress(hex: "0xF4A2CB946f72e1460C490bF490E73d81295130cd", eip55: false)
-            let data = EthereumData(bytes: "hello world".bytes)
-            let values: EthereumValue = [address, data]
-            let message = MessageSignatureObject(params: [values])
-            XCTAssertEqual(message?.from, address)
-            XCTAssertEqual(message?.message, data)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-    
-    func testCreateSignPayloadFromInvalidParams() {
-        do {
-            let address = try EthereumAddress(hex: "0xF4A2CB946f72e1460C490bF490E73d81295130cd", eip55: false)
-            let data = EthereumData(bytes: "hello world".bytes)
-            let values: EthereumValue = [data, address]
-            let message = MessageSignatureObject(params: [values])
-            XCTAssertNil(message, "The message is not created when values do not match expected input")
-            let message2 = MessageSignatureObject(params: [])
-            XCTAssertNil(message2, "The message is not created when passing an empty array")
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
 }

--- a/Example/Tests/MockAuthDelegate.swift
+++ b/Example/Tests/MockAuthDelegate.swift
@@ -1,0 +1,22 @@
+//
+//  MockAuthDelegate.swift
+//  Bitski_Example
+//
+//  Created by Josh Pyles on 6/11/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import Bitski
+
+class MockAuthDelegate: NSObject, BitskiAuthDelegate {
+    var isLoggedIn: Bool = true
+    
+    func getCurrentAccessToken(completion: @escaping (String?, Error?) -> Void) {
+        if isLoggedIn {
+            completion("test-access-token", nil)
+        } else {
+            completion(nil, Bitski.AuthenticationError.notLoggedIn)
+        }
+    }
+}

--- a/Example/Tests/MockAuthenticationAgent.swift
+++ b/Example/Tests/MockAuthenticationAgent.swift
@@ -36,49 +36,10 @@ class MockAuthenticationWebSession: AuthorizationSessionProtocol {
     
 }
 
-class MockTransactionWebSession: AuthorizationSessionProtocol {
-    
-    let handler: () -> Void
-    
+class MockEmptyURLAuthorizationSession: MockAuthorizationSession {
     required init(url: URL, callbackURLScheme: String?, completionHandler: @escaping (URL?, Error?) -> Void) {
-        let path = OHPathForFile("send-transaction.json", type(of: self))!
-        let data = try! Data.init(contentsOf: URL(fileURLWithPath: path))
-        let url = URL(string: "bitskiexample://application/callback?result=\(data.base64EncodedString())")!
-        self.handler = {
-            completionHandler(url, nil)
-        }
+        super.init(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
+        let url = URL(string: "example://application/callback")
+        result = (url, nil)
     }
-    
-    func start() -> Bool {
-        handler()
-        return true
-    }
-    
-    func cancel() {
-        
-    }
-    
-}
-
-/// Mock agent that always returns an error
-class MockFailingWebSession: AuthorizationSessionProtocol {
-    
-    let handler: () -> Void
-    
-    required init(url: URL, callbackURLScheme: String?, completionHandler: @escaping (URL?, Error?) -> Void) {
-        let error = NSError(domain: "com.bitski.bitski_tests", code: 500, userInfo: [NSLocalizedDescriptionKey: "User cancelled"])
-        self.handler = {
-            completionHandler(nil, error)
-        }
-    }
-    
-    func start() -> Bool {
-        handler()
-        return true
-    }
-    
-    func cancel() {
-        
-    }
-    
 }

--- a/Example/Tests/MockTransactionSigner.swift
+++ b/Example/Tests/MockTransactionSigner.swift
@@ -1,0 +1,34 @@
+//
+//  MockTransactionSigner.swift
+//  Bitski_Tests
+//
+//  Created by Josh Pyles on 6/11/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+@testable import Bitski
+
+class MockTransactionSigner: TransactionSigner {
+    
+    var authAgentType: AuthorizationSessionProtocol.Type = MockTransactionWebSession.self
+    
+    override func createAuthorizationAgent() -> BitskiAuthorizationAgent {
+        let agent = super.createAuthorizationAgent()
+        agent.authorizationSessionType = authAgentType
+        return agent
+    }
+    
+    // Allows us to simulate a failed encoding
+    var shouldEncode: Bool = true
+    
+    override func encode<T: Encodable>(body: T, withPrefix prefix: String? = nil) -> Promise<Data> {
+        if shouldEncode {
+            return super.encode(body: body, withPrefix: prefix)
+        } else {
+            return Promise(error: NSError(domain: "com.bitski.bitski_tests", code: 500, userInfo: [NSLocalizedDescriptionKey: "Encoding failed"]))
+        }
+    }
+    
+}

--- a/Example/Tests/NetworkClientTests.swift
+++ b/Example/Tests/NetworkClientTests.swift
@@ -18,8 +18,9 @@ class NetworkClientTests: XCTestCase {
     func testEncodingFailedCallback() {
         let exp = expectation(description: "Callback is called")
         let client = NetworkClient(session: .shared)
-        client.encode(body: Float.nan) { data, error in
-            XCTAssertNil(data)
+        client.encode(body: Float.nan).done { data in
+            XCTFail()
+        }.catch { error in
             XCTAssertNotNil(error)
             exp.fulfill()
         }
@@ -35,11 +36,11 @@ class NetworkClientTests: XCTestCase {
         let response = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
         session.response = response
         let client = NetworkClient(session: session)
-        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil) { data, error in
-            XCTAssertNil(data)
-            XCTAssertNotNil(error)
+        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil).done { data in
+            XCTFail()
+        }.catch { error in
             switch error {
-            case NetworkClient.Error.unexpectedResponse?:
+            case NetworkClient.Error.unexpectedResponse:
                 break
             default:
                 XCTFail("Wrong error received")
@@ -57,11 +58,11 @@ class NetworkClientTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
         session.response = response
         let client = NetworkClient(session: session)
-        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil) { data, error in
-            XCTAssertNil(data)
-            XCTAssertNotNil(error)
+        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil).done { data in
+            XCTFail()
+        }.catch { error in
             switch error {
-            case NetworkClient.Error.unexpectedResponse?:
+            case NetworkClient.Error.unexpectedResponse:
                 break
             default:
                 XCTFail("Wrong error received")
@@ -82,11 +83,11 @@ class NetworkClientTests: XCTestCase {
         session.error = testError
         session.response = response
         let client = NetworkClient(session: session)
-        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil) { data, error in
-            XCTAssertNil(data)
-            XCTAssertNotNil(error)
+        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil).done { data in
+            XCTFail()
+        }.catch { error in
             switch error {
-            case NetworkClient.Error.unexpectedResponse(let underlyingError)?:
+            case NetworkClient.Error.unexpectedResponse(let underlyingError):
                 XCTAssertEqual(underlyingError?.localizedDescription, testError.localizedDescription)
                 break
             default:
@@ -106,11 +107,11 @@ class NetworkClientTests: XCTestCase {
         session.data = Data(bytes: [])
         session.response = response
         let client = NetworkClient(session: session)
-        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil) { data, error in
-            XCTAssertNil(data)
-            XCTAssertNotNil(error)
+        client.sendRequest(url: url, accessToken: nil, method: "POST", body: nil).done { data in
+            XCTFail()
+        }.catch { error in
             switch error {
-            case NetworkClient.Error.invalidResponseCode?:
+            case NetworkClient.Error.invalidResponseCode:
                 break
             default:
                 XCTFail("Wrong error received")

--- a/Example/Tests/Stubs/Stubs.swift
+++ b/Example/Tests/Stubs/Stubs.swift
@@ -82,6 +82,12 @@ class BitskiTestStubs {
         }
     }
     
+    static func stubSignTransactionAPI() {
+        stub(condition: isHost("api.bitski.com") && isPath("/v1/transactions")) { request -> OHHTTPStubsResponse in
+            return OHHTTPStubsResponse(jsonFileNamed: "create-sign-transaction.json")
+        }
+    }
+    
     static func stubTransactionAPIError() {
         stub(condition: isHost("api.bitski.com") && isPath("/v1/transactions")) { request -> OHHTTPStubsResponse in
             return OHHTTPStubsResponse(jsonFileNamed: "error.json", statusCode: 401, headers: ["Content-Type": "application/json"])
@@ -91,6 +97,12 @@ class BitskiTestStubs {
     static func stubTransactionAPIInvalid() {
         stub(condition: isHost("api.bitski.com") && isPath("/v1/transactions")) { request -> OHHTTPStubsResponse in
             return OHHTTPStubsResponse(jsonFileNamed: "empty.json")
+        }
+    }
+    
+    static func stubSendRawTransaction() {
+        stub(condition: isHost("api.bitski.com") && isPath("/v1/web3/kovan") && isMethod("eth_sendRawTransaction")) { request -> OHHTTPStubsResponse in
+            return OHHTTPStubsResponse(jsonFileNamed: "send-transaction.json")
         }
     }
 

--- a/Example/Tests/Stubs/create-sign-transaction.json
+++ b/Example/Tests/Stubs/create-sign-transaction.json
@@ -1,0 +1,23 @@
+{
+    "clients": [{
+        "client_id": "ae94eec9-2af0-405c-bc42-1e909f3b5190",
+        "client_name": "Bitski Example DApp",
+        "client_uri": "https://example-dapp-1.bitski.com",
+        "logo_uri": "https://example-dapp-1.bitski.com/assets/character-5.png",
+        "policy_uri": "",
+        "tos_uri": ""
+    }],
+    "transaction": {
+        "clientId": "ae94eec9-2af0-405c-bc42-1e909f3b5190",
+        "context": {
+            "chainId": 4
+        },
+        "id": "16a82f91-ff87-42d5-bbca-0c5cc2e24982",
+        "kind": "ETH_SIGN",
+        "payload": {
+            "message": "0x50bb4e7f000000000000000000000000c20c5ccb44e6092c712a1b895df6d72ea53b40f5005c45d755946622678db45c9d893c1264a6965ccbe908b1f993c688cacf2dea0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000007868747470733a2f2f6578616d706c652d646170702d312d6170692e626974736b692e636f6d2f746f6b656e732f3136333033313935353835383636353932383639393839363338343332323934333130333534353735363239363334383034373237333331303639323038393336323535373930363431300000000000000000",
+            "from": "0xc20c5ccb44e6092c712a1b895df6d72ea53b40f5",
+        },
+        "submitterId": "5ee5dabd-d5ac-4a4f-ae85-b4301a8bbad2"
+    }
+}

--- a/Example/Tests/TransactionSignerTests.swift
+++ b/Example/Tests/TransactionSignerTests.swift
@@ -1,0 +1,203 @@
+//
+//  TransactionSignerTests.swift
+//  Bitski_Tests
+//
+//  Created by Josh Pyles on 6/10/19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+import Web3
+import PromiseKit
+import OHHTTPStubs
+@testable import Bitski
+
+class TransactionSignerTests: XCTestCase {
+    
+    var authDelegate: MockAuthDelegate?
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        authDelegate = MockAuthDelegate()
+    }
+
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        authDelegate = nil
+    }
+    
+    func testSign() {
+        BitskiTestStubs.stubSignTransactionAPI()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        let address = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let message = EthereumData(bytes: [])
+        let promise = expectation(description: "Promise should resolve")
+        firstly {
+            signer.sign(from: address, message: message)
+        }.done { (result: EthereumData) in
+            // assertions
+            XCTAssertNotNil(result)
+            promise.fulfill()
+        }.catch { error in
+            XCTFail("Should not error: \(error.localizedDescription)")
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func testSignTransaction() {
+        BitskiTestStubs.stubTransactionAPI()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        let address = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: address, to: address, value: 0, data: EthereumData(bytes: []))
+        let promise = expectation(description: "Promise should resolve")
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            // assertions
+            XCTAssertNotNil(result)
+            promise.fulfill()
+        }.catch { error in
+            XCTFail("Should not error: \(error.localizedDescription)")
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func testTransactionNoDelegate() {
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        let promise = expectation(description: "Should send a transaction")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            if case TransactionSigner.SignerError.noDelegate = error {
+                
+            } else {
+                XCTFail("Received the wrong error")
+            }
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testTransactionError() {
+        BitskiTestStubs.stubTransactionAPIError()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        let promise = expectation(description: "Should send a transaction")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testTransactionInvalidResponse() {
+        BitskiTestStubs.stubTransactionAPIInvalid()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        let promise = expectation(description: "Should send a transaction")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    /// Simulates a case where the transacation fails to be encoded
+    func testTransactionEncodingFailed() {
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        signer.shouldEncode = false
+        let promise = expectation(description: "Callback is called")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    
+    func testTransactionUserCancelled() {
+        BitskiTestStubs.stubTransactionAPI()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        signer.authAgentType = MockCancelledWebSession.self
+        let promise = expectation(description: "Callback is called")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testTransactionRPCError() {
+        BitskiTestStubs.stubTransactionAPI()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        signer.authAgentType = MockTransactionRPCErrorWebSession.self
+        let promise = expectation(description: "Callback is called")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testTransactionEmptyRPC() {
+        BitskiTestStubs.stubTransactionAPI()
+        let signer = MockTransactionSigner(apiBaseURL: URL(string: "https://api.bitski.com/v1/")!, webBaseURL: URL(string: "https://sign.bitski.com")!, redirectURL: URL(string: "bitskiexample://application/callback")!)
+        signer.authDelegate = authDelegate
+        signer.authAgentType = MockTransactionRPCEmptyResponseSession.self
+        let promise = expectation(description: "Callback is called")
+        let testAddress = try! EthereumAddress(hex: "0x9F2c4Ea0506EeAb4e4Dc634C1e1F4Be71D0d7531", eip55: false)
+        let transaction = EthereumTransaction(nonce: 0, gasPrice: 0, gas: 0, from: testAddress, to: testAddress, value: 0, data: EthereumData(bytes: []))
+        firstly {
+            signer.sign(transaction: transaction)
+        }.done { (result: EthereumData) in
+            XCTFail("Should not succeed")
+            promise.fulfill()
+        }.catch { error in
+            promise.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+}


### PR DESCRIPTION
- Added support to eth-sign in web3.swift.
- Moved the signing logic into a separate class, for more direct top-level access and less buggy dynamic type checking.
- Added `Bitski.sign(from:message:)` and `Bitski.sign(transaction:)` to the top level API
- Added more flexible `sendRawTransaction()` method to Web3 to accept signed data